### PR TITLE
chore(cicd): exclude prs with title `Automated version bump`

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   checks:
+    if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"
     name: Clippy & fmt
     runs-on: ubuntu-latest
     steps:
@@ -47,6 +48,7 @@ jobs:
         run: cargo clippy --all-targets
 
   check_pr_size:
+    if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"
     name: Check PR size doesn't break set limit
     runs-on: ubuntu-latest
     steps:
@@ -58,6 +60,7 @@ jobs:
           max_lines_changed: 200
   
   coverage:
+    if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"
     name: Code coverage check
     runs-on: ubuntu-latest
     env: 
@@ -99,6 +102,7 @@ jobs:
           parallel-finished: true
 
   cargo-udeps:
+    if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"
     name: Unused dependency check
     runs-on: ubuntu-latest
     steps:
@@ -117,6 +121,7 @@ jobs:
           cargo +nightly udeps --all-targets
 
   cargo-deny:
+    if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -128,6 +133,7 @@ jobs:
     - uses: EmbarkStudios/cargo-deny-action@v1
 
   test:
+    if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"
     name: Test
     runs-on: ${{ matrix.os }}
     strategy:
@@ -160,6 +166,7 @@ jobs:
 
   # Test publish using --dry-run.
   test-publish:
+    if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"
     name: Test Publish
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/security_audit.yml
+++ b/.github/workflows/security_audit.yml
@@ -4,6 +4,7 @@ on:
     - cron: '0 0 * * *'
 jobs:
   audit:
+    if: github.repository_owner == 'maidsafe'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
PRs starting with the title `Automated version bump` are auto generated as
part of the CI/CD process and so it is duplicate work running the PR workflow
on them. These changes skip PR CI for them.
This PR also switches the scheduled security audit to only run on the MaidSafe
org repo, not on forks.

Note that clippy will fail on this PR, but this is being fixed in PR #19