### PR TITLE
feat(mint): take input hashes belonging to mint, in reissue method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ quickcheck = "1"
 quickcheck_macros = "1"
 rand = "0.7.1"
 bls_dkg = "0.3"
+threshold_crypto = "0.4"
 
   [dependencies.tiny-keccak]
   version = "2.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ thiserror = "1.0.24"
 quickcheck = "1"
 quickcheck_macros = "1"
 rand = "0.7.1"
-bls_dkg = "0.3"
+bls_dkg = "~0.3.8"
 threshold_crypto = "0.4"
 
   [dependencies.tiny-keccak]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ thiserror = "1.0.24"
 quickcheck = "1"
 quickcheck_macros = "1"
 rand = "0.7.1"
+bls_dkg = "0.3"
 
   [dependencies.tiny-keccak]
   version = "2.0.0"

--- a/src/dbc.rs
+++ b/src/dbc.rs
@@ -78,7 +78,9 @@ mod tests {
 
         let outputs = divide(dbc.amount(), n_ways)
             .enumerate()
-            .map(|(i, amount)| DbcContent::new(input_hashes.clone(), amount, i as u8))
+            .map(|(i, amount)| {
+                DbcContent::new(input_hashes.clone(), amount, i as u8, crate::bls_dkg_id())
+            })
             .collect();
 
         MintRequest { inputs, outputs }
@@ -90,6 +92,7 @@ mod tests {
             parents: Default::default(),
             amount: 100,
             output_number: 0,
+            owner: crate::bls_dkg_id(),
         };
 
         let input_content_hashes: BTreeSet<_> = vec![input_content.hash()].into_iter().collect();
@@ -144,7 +147,7 @@ mod tests {
         let input_hashes: BTreeSet<DbcContentHash> =
             inputs.iter().map(|in_dbc| in_dbc.name()).collect();
 
-        let content = DbcContent::new(input_hashes.clone(), amount, 0);
+        let content = DbcContent::new(input_hashes.clone(), amount, 0, crate::bls_dkg_id());
         let outputs = vec![content].into_iter().collect();
 
         let mint_request = MintRequest { inputs, outputs };
@@ -167,6 +170,7 @@ mod tests {
             fuzzed_parents,
             amount + extra_output_amount.coerce::<u64>(),
             0,
+            crate::bls_dkg_id(),
         );
 
         let mut fuzzed_transaction_sigs = BTreeMap::new();

--- a/src/dbc.rs
+++ b/src/dbc.rs
@@ -159,8 +159,14 @@ mod tests {
             n_inputs.coerce(),
             &input_owner.public_key_set,
         );
+        let input_hashes = mint_request
+            .transaction
+            .inputs
+            .iter()
+            .map(|i| i.name())
+            .collect();
         let (split_transaction, split_transaction_sigs) =
-            genesis.reissue(mint_request.clone()).unwrap();
+            genesis.reissue(mint_request.clone(), input_hashes).unwrap();
 
         assert_eq!(split_transaction, mint_request.transaction.blinded());
 
@@ -204,7 +210,9 @@ mod tests {
             input_ownership_proofs,
         };
 
-        let (transaction, transaction_sigs) = genesis.reissue(mint_request.clone()).unwrap();
+        let (transaction, transaction_sigs) = genesis
+            .reissue(mint_request.clone(), input_hashes.clone())
+            .unwrap();
         assert_eq!(mint_request.transaction.blinded(), transaction);
 
         let fuzzed_parents = BTreeSet::from_iter(

--- a/src/dbc.rs
+++ b/src/dbc.rs
@@ -78,8 +78,11 @@ mod tests {
 
         let outputs = divide(dbc.amount(), n_ways)
             .enumerate()
-            .map(|(i, amount)| {
-                DbcContent::new(input_hashes.clone(), amount, i as u8, crate::bls_dkg_id())
+            .map(|(i, amount)| DbcContent {
+                parents: input_hashes.clone(),
+                amount,
+                output_number: i as u8,
+                owner: crate::bls_dkg_id().public_key_set,
             })
             .collect();
 
@@ -95,7 +98,7 @@ mod tests {
             parents: Default::default(),
             amount: 100,
             output_number: 0,
-            owner: crate::bls_dkg_id(),
+            owner: crate::bls_dkg_id().public_key_set,
         };
 
         let input_content_hashes: BTreeSet<_> = vec![input_content.hash()].into_iter().collect();
@@ -128,8 +131,8 @@ mod tests {
         n_drop_parents: TinyInt,       // # of valid parents to drop from output DBC
     ) {
         let amount = 100;
-
-        let (mut genesis, genesis_dbc) = Mint::genesis(amount);
+        let genesis_owner = crate::bls_dkg_id();
+        let (mut genesis, genesis_dbc) = Mint::genesis(genesis_owner.public_key_set, amount);
 
         let mint_request = prepare_even_split(&genesis_dbc, n_inputs.coerce());
         let (split_transaction, split_transaction_sigs) =
@@ -151,7 +154,12 @@ mod tests {
         let input_hashes: BTreeSet<DbcContentHash> =
             inputs.iter().map(|in_dbc| in_dbc.name()).collect();
 
-        let content = DbcContent::new(input_hashes.clone(), amount, 0, crate::bls_dkg_id());
+        let content = DbcContent {
+            parents: input_hashes.clone(),
+            amount,
+            output_number: 0,
+            owner: crate::bls_dkg_id().public_key_set,
+        };
         let outputs = vec![content].into_iter().collect();
 
         let mint_request = MintRequest {
@@ -173,12 +181,12 @@ mod tests {
             )
             .collect();
 
-        let fuzzed_content = DbcContent::new(
-            fuzzed_parents,
-            amount + extra_output_amount.coerce::<u64>(),
-            0,
-            crate::bls_dkg_id(),
-        );
+        let fuzzed_content = DbcContent {
+            parents: fuzzed_parents,
+            amount: amount + extra_output_amount.coerce::<u64>(),
+            output_number: 0,
+            owner: crate::bls_dkg_id().public_key_set,
+        };
 
         let mut fuzzed_transaction_sigs = BTreeMap::new();
 

--- a/src/dbc_content.rs
+++ b/src/dbc_content.rs
@@ -7,6 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 use std::collections::BTreeSet;
 
+use bls_dkg::PublicKeySet;
 use serde::{Deserialize, Serialize};
 use tiny_keccak::{Hasher, Sha3};
 
@@ -14,15 +15,20 @@ use crate::DbcContentHash;
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub struct DbcContent {
-    pub parents: BTreeSet<DbcContentHash>, // Hash of parent DbcContent. Also used as a nonce
-    // TODO: pub owner: PubKey
+    pub parents: BTreeSet<DbcContentHash>, // Parent DBC's, acts as a nonce
     pub amount: u64,
     pub output_number: u8,
+    pub owner: PublicKeySet,
 }
 
 impl DbcContent {
     // Create a new DbcContent for signing. TODO: blind the owner from the mint
-    pub fn new(parents: BTreeSet<DbcContentHash>, amount: u64, output_number: u8) -> Self {
+    pub fn new(
+        parents: BTreeSet<DbcContentHash>,
+        amount: u64,
+        output_number: u8,
+        owner: PublicKeySet,
+    ) -> Self {
         // let mut owner = owner;
         // for _ in 0..amount % 1000 {
         //     owner = sha3_256(&owner); // owner not visible to mint, until out_dbc is minted.
@@ -31,6 +37,7 @@ impl DbcContent {
             parents,
             amount,
             output_number,
+            owner,
         }
     }
 

--- a/src/dbc_content.rs
+++ b/src/dbc_content.rs
@@ -18,7 +18,7 @@ pub struct DbcContent {
     pub parents: BTreeSet<DbcContentHash>, // Parent DBC's, acts as a nonce
     pub amount: u64,
     pub output_number: u8,
-    pub owner: PublicKeySet,
+    pub owner: PublicKeySet, // TAI: should this be threshold_crypto::PublicKey? (PublicKeySet::public_key())
 }
 
 impl DbcContent {

--- a/src/dbc_content.rs
+++ b/src/dbc_content.rs
@@ -7,8 +7,8 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 use std::collections::BTreeSet;
 
-use threshold_crypto::PublicKeySet;
 use serde::{Deserialize, Serialize};
+use threshold_crypto::PublicKeySet;
 use tiny_keccak::{Hasher, Sha3};
 
 use crate::DbcContentHash;

--- a/src/dbc_content.rs
+++ b/src/dbc_content.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 use std::collections::BTreeSet;
 
-use bls_dkg::PublicKeySet;
+use threshold_crypto::PublicKeySet;
 use serde::{Deserialize, Serialize};
 use tiny_keccak::{Hasher, Sha3};
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -28,6 +28,8 @@ pub enum Error {
     UnrecognisedAuthority,
     #[error("At least one transaction input is missing a signature.")]
     MissingSignatureForInput,
+    #[error("At least one input is missing an ownership proof")]
+    MissingInputOwnerProof,
     #[error("Mint request doesn't balance out sum(input) == sum(output)")]
     DbcMintRequestDoesNotBalance { input: u64, output: u64 },
     #[error("Outputs must be numbered 0..N where N = # of outputs")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,6 +22,8 @@ pub enum Error {
     InvalidOperation(String),
     #[error("This input has a signature, but it doesn't appear in the transaction")]
     UnknownInput,
+    #[error("Filtered input doesn't appear in the transaction")]
+    FilteredInputNotPresent,
     #[error("Failed signature check.")]
     FailedSignature,
     #[error("Unrecognised authority.")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,6 @@ pub(crate) fn bls_dkg_id() -> bls_dkg::outcome::Outcome {
         }
     }
 
-
     let (_, outcome) = key_gen.generate_keys().unwrap();
     outcome
 }
@@ -135,9 +134,9 @@ mod tests {
     pub struct TinyVec<T>(Vec<T>);
 
     impl<T> TinyVec<T> {
-	pub fn into_iter(self) -> impl Iterator<Item=T> {
-	    self.0.into_iter()
-	}
+        pub fn into_iter(self) -> impl Iterator<Item = T> {
+            self.0.into_iter()
+        }
     }
 
     impl<T: std::fmt::Debug> std::fmt::Debug for TinyVec<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
+#![allow(clippy::from_iter_instead_of_collect)]
 
 #[cfg(test)]
 use tiny_keccak::{Hasher, Sha3};
@@ -45,14 +46,12 @@ pub(crate) fn bls_dkg_id() -> bls_dkg::outcome::Outcome {
 
     let mut msgs = vec![proposal];
     while let Some(msg) = msgs.pop() {
-        println!("Processing {:?}", msg);
         match key_gen.handle_message(&mut rand::thread_rng(), msg) {
             Ok(response_msgs) => msgs.extend(response_msgs),
             Err(e) => panic!("Error while generating BLS key: {:?}", e),
         }
     }
 
-    println!("After processing messages: {:?}", key_gen.phase());
 
     let (_, outcome) = key_gen.generate_keys().unwrap();
     outcome
@@ -136,9 +135,9 @@ mod tests {
     pub struct TinyVec<T>(Vec<T>);
 
     impl<T> TinyVec<T> {
-        pub fn vec(self) -> Vec<T> {
-            self.0
-        }
+	pub fn into_iter(self) -> impl Iterator<Item=T> {
+	    self.0.into_iter()
+	}
     }
 
     impl<T: std::fmt::Debug> std::fmt::Debug for TinyVec<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,8 @@ pub use crate::{
     mint::{Mint, MintRequest, MintTransaction},
 };
 
-pub(crate) fn bls_dkg_id() -> bls_dkg::PublicKeySet {
+#[cfg(test)]
+pub(crate) fn bls_dkg_id() -> bls_dkg::outcome::Outcome {
     use std::collections::BTreeSet;
     use std::iter::FromIterator;
 
@@ -54,7 +55,7 @@ pub(crate) fn bls_dkg_id() -> bls_dkg::PublicKeySet {
     println!("After processing messages: {:?}", key_gen.phase());
 
     let (_, outcome) = key_gen.generate_keys().unwrap();
-    outcome.public_key_set
+    outcome
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub use crate::{
     dbc_transaction::DbcTransaction,
     error::{Error, Result},
     key_manager::{ChainNode, KeyCache, KeyManager, PublicKey, Signature},
-    mint::{Mint, MintRequest},
+    mint::{Mint, MintRequest, MintTransaction},
 };
 
 pub(crate) fn bls_dkg_id() -> bls_dkg::PublicKeySet {

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -74,7 +74,7 @@ impl Mint {
         let genesis_input = [0u8; 32];
 
         let parents = vec![genesis_input].into_iter().collect();
-        let content = DbcContent::new(parents, amount, 0);
+        let content = DbcContent::new(parents, amount, 0, crate::bls_dkg_id());
 
         let transaction = DbcTransaction {
             inputs: vec![genesis_input].into_iter().collect(),
@@ -218,7 +218,9 @@ mod tests {
         let outputs = output_amounts
             .iter()
             .enumerate()
-            .map(|(i, amount)| DbcContent::new(input_hashes.clone(), *amount, i as u8))
+            .map(|(i, amount)| {
+                DbcContent::new(input_hashes.clone(), *amount, i as u8, crate::bls_dkg_id())
+            })
             .collect();
 
         let mint_request = MintRequest { inputs, outputs };
@@ -275,16 +277,21 @@ mod tests {
 
         let mint_request = MintRequest {
             inputs: inputs.clone(),
-            outputs: vec![DbcContent::new(input_hashes.clone(), 1000, 0)]
-                .into_iter()
-                .collect(),
+            outputs: vec![DbcContent::new(
+                input_hashes.clone(),
+                1000,
+                0,
+                crate::bls_dkg_id(),
+            )]
+            .into_iter()
+            .collect(),
         };
 
         let (t, s) = genesis.reissue(mint_request).unwrap();
 
         let double_spend_mint_request = MintRequest {
             inputs,
-            outputs: vec![DbcContent::new(input_hashes, 1000, 1)]
+            outputs: vec![DbcContent::new(input_hashes, 1000, 1, crate::bls_dkg_id())]
                 .into_iter()
                 .collect(),
         };
@@ -334,7 +341,14 @@ mod tests {
         let input_content: HashSet<_> = input_amounts
             .iter()
             .enumerate()
-            .map(|(i, amount)| DbcContent::new(gen_input_hashes.clone(), *amount, i as u8))
+            .map(|(i, amount)| {
+                DbcContent::new(
+                    gen_input_hashes.clone(),
+                    *amount,
+                    i as u8,
+                    crate::bls_dkg_id(),
+                )
+            })
             .collect();
 
         let mint_request = MintRequest {
@@ -367,7 +381,7 @@ mod tests {
                     fuzzed_parents.insert(rand::random());
                 }
 
-                DbcContent::new(fuzzed_parents, *amount, *output_number)
+                DbcContent::new(fuzzed_parents, *amount, *output_number, crate::bls_dkg_id())
             })
             .collect();
 
@@ -474,6 +488,7 @@ mod tests {
             parents: Default::default(),
             amount: 100,
             output_number: 0,
+            owner: crate::bls_dkg_id(),
         };
         let input_content_hashes: BTreeSet<_> = vec![input_content.hash()].into_iter().collect();
 
@@ -492,6 +507,7 @@ mod tests {
                 parents: input_content_hashes,
                 amount: 100,
                 output_number: 0,
+                owner: crate::bls_dkg_id(),
             }]
             .into_iter()
             .collect(),


### PR DESCRIPTION
- Add custom error for validation that the filtered input actually is present in the transaction as well.