### PR TITLE
feat(mint): take input hashes belonging to mint, in reissue method

### DIFF
--- a/src/dbc.rs
+++ b/src/dbc.rs
@@ -159,8 +159,14 @@ mod tests {
             n_inputs.coerce(),
             &input_owner.public_key_set,
         );
+        let input_hashes = mint_request
+            .transaction
+            .inputs
+            .iter()
+            .map(|i| i.name())
+            .collect();
         let (split_transaction, split_transaction_sigs) =
-            genesis.reissue(mint_request.clone()).unwrap();
+            genesis.reissue(mint_request.clone(), input_hashes).unwrap();
 
         assert_eq!(split_transaction, mint_request.transaction.blinded());
 
@@ -204,7 +210,9 @@ mod tests {
             input_ownership_proofs,
         };
 
-        let (transaction, transaction_sigs) = genesis.reissue(mint_request.clone()).unwrap();
+        let (transaction, transaction_sigs) = genesis
+            .reissue(mint_request.clone(), input_hashes.clone())
+            .unwrap();
         assert_eq!(mint_request.transaction.blinded(), transaction);
 
         let fuzzed_parents = BTreeSet::from_iter(

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,6 +22,8 @@ pub enum Error {
     InvalidOperation(String),
     #[error("This input has a signature, but it doesn't appear in the transaction")]
     UnknownInput,
+    #[error("Filtered input doesn't appear in the transaction")]
+    FilteredInputNotPresent,
     #[error("Failed signature check.")]
     FailedSignature,
     #[error("Unrecognised authority.")]


### PR DESCRIPTION
- Add custom error for validation that the filtered input actually is
present in the transaction as well.