### PR TITLE
Hash pr

### DIFF
--- a/src/dbc.rs
+++ b/src/dbc.rs
@@ -269,7 +269,7 @@ mod tests {
         // Valid mint signatures BUT signing wrong message
         for _ in 0..n_wrong_msg_sigs.coerce() {
             if let Some(input) = repeating_inputs.next() {
-                let wrong_msg_sig = genesis.key_mgr.sign(&[0u8; 32]);
+                let wrong_msg_sig = genesis.key_mgr.sign(&Hash([0u8; 32]));
                 fuzzed_transaction_sigs.insert(input.name(), (genesis.public_key(), wrong_msg_sig));
             }
         }

--- a/src/dbc_content.rs
+++ b/src/dbc_content.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use threshold_crypto::PublicKeySet;
 use tiny_keccak::{Hasher, Sha3};
 
-use crate::DbcContentHash;
+use crate::{DbcContentHash, Hash};
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub struct DbcContent {
@@ -56,6 +56,6 @@ impl DbcContent {
 
         let mut hash = [0; 32];
         sha3.finalize(&mut hash);
-        hash
+        Hash(hash)
     }
 }

--- a/src/dbc_transaction.rs
+++ b/src/dbc_transaction.rs
@@ -38,7 +38,7 @@ impl DbcTransaction {
 
         let mut hash = [0; 32];
         sha3.finalize(&mut hash);
-        hash
+        Hash(hash)
     }
 }
 
@@ -54,10 +54,14 @@ mod tests {
     #[quickcheck]
     fn prop_hash_is_independent_of_order(inputs: Vec<u64>, outputs: Vec<u64>) {
         // This test is here to protect us in the case that someone swaps out the BTreeSet for inputs/outputs for something else
-        let input_hashes: Vec<DbcContentHash> =
-            inputs.iter().map(|i| sha3_256(&i.to_be_bytes())).collect();
-        let output_hashes: Vec<DbcContentHash> =
-            outputs.iter().map(|i| sha3_256(&i.to_be_bytes())).collect();
+        let input_hashes: Vec<DbcContentHash> = inputs
+            .iter()
+            .map(|i| Hash(sha3_256(&i.to_be_bytes())))
+            .collect();
+        let output_hashes: Vec<DbcContentHash> = outputs
+            .iter()
+            .map(|i| Hash(sha3_256(&i.to_be_bytes())))
+            .collect();
 
         let forward_hash = DbcTransaction::new(
             input_hashes.iter().cloned().collect(),

--- a/src/key_manager.rs
+++ b/src/key_manager.rs
@@ -47,7 +47,11 @@ impl PublicKey {
 
         let mut hash = [0; 32];
         sha3.finalize(&mut hash);
-        hash
+        Hash(hash)
+    }
+
+    pub fn to_bytes(&self) -> [u8; 32] {
+        self.0.to_bytes()
     }
 
     pub fn ed(&self) -> EdPublicKey {
@@ -65,7 +69,7 @@ pub fn ed25519_keypair() -> Keypair {
     Keypair::generate(&mut rand::thread_rng())
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct KeyCache(HashSet<PublicKey>);
 
 impl KeyCache {
@@ -100,6 +104,7 @@ pub struct ChainNode {
     prev_mint_sig: Signature,
 }
 
+#[derive(Debug)]
 pub struct KeyManager {
     keypair: Keypair,
     genesis: PublicKey,

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -16,13 +16,13 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 use crate::{
-    Dbc, DbcContent, DbcContentHash, DbcTransaction, Error, KeyCache, KeyManager, PublicKey,
+    Dbc, DbcContent, DbcContentHash, DbcTransaction, Error, Hash, KeyCache, KeyManager, PublicKey,
     Result, Signature,
 };
 
 pub type InputSignatures = BTreeMap<DbcContentHash, (PublicKey, Signature)>;
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 struct SpendBook {
     transactions: BTreeMap<DbcContentHash, DbcTransaction>,
 }
@@ -116,6 +116,7 @@ pub struct MintRequest {
     pub input_ownership_proofs: HashMap<DbcContentHash, threshold_crypto::Signature>,
 }
 
+#[derive(Debug)]
 pub struct Mint {
     pub(crate) key_mgr: KeyManager,
     spendbook: SpendBook,
@@ -125,7 +126,7 @@ impl Mint {
     pub fn genesis(genesis_key: threshold_crypto::PublicKeySet, amount: u64) -> (Self, Dbc) {
         let key_mgr = KeyManager::new_genesis();
 
-        let genesis_input = [0u8; 32];
+        let genesis_input = Hash([0u8; 32]);
 
         let parents = vec![genesis_input].into_iter().collect();
         let content = DbcContent::new(parents, amount, 0, genesis_key);


### PR DESCRIPTION
These are some mods I made to enable displaying mint and dbc information nicely in a CLI.

The largest part of the PR changes `Hash` to use newtype pattern instead of a type alias.  I initially did this in order to impl fmt::Display and Debug on Hash for pretty printing using base64 encoding.  However, I discovered that fmt::Display really cannot do what I need, so in the end the app does all the display formatting itself.  I also reverted the custom base64 encoding in Hash::Debug, as I figure it is perhaps better to display the raw data/structure in Debug mode.  As such, the newtype pattern could be reverted from the PR, but I think it is useful to keep, as it makes it easy/possible to add functionality to Hash and DbcContentHash in the future.

Other changes are:
* adds PublicKey::to_bytes()
* derive Debug for Mint, KeyCache, KeyManager, SpendBook

These last two are relied upon by the cli mint prototype.