### PR TITLE
export GENESIS_DBC_INPUT so API users can create a Genesis Dbc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ pub use crate::{
     dbc_transaction::DbcTransaction,
     error::{Error, Result},
     key_manager::{KeyCache, KeyManager, NodeSignature, PublicKey, PublicKeySet, Signature},
-    mint::{Mint, ReissueRequest, ReissueTransaction},
+    mint::{Mint, ReissueRequest, ReissueTransaction, GENESIS_DBC_INPUT},
 };
 
 impl From<[u8; 32]> for Hash {


### PR DESCRIPTION
I made this one line change in order to mint a Genesis Dbc from another crate.

There may be cleaner alternatives though, like:
* The mint could accept a byte array from caller to use.
* or the Hash(GENESIS_DBC_INPUT) could be returned from Mint::issue_genesis_dbc()