### PR TITLE
refactor(signing): use signer trait instead of secret key share

### DIFF
--- a/benches/reissue.rs
+++ b/benches/reissue.rs
@@ -3,16 +3,22 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::iter::FromIterator;
 
-use sn_dbc::{bls_dkg_id, Dbc, DbcContent, KeyManager, Mint, ReissueRequest, ReissueTransaction};
+use sn_dbc::{
+    bls_dkg_id, Dbc, DbcContent, ExposedSigner, KeyManager, Mint, ReissueRequest,
+    ReissueTransaction,
+};
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
-fn genesis(amount: u64) -> (Mint, bls_dkg::outcome::Outcome, Dbc) {
+fn genesis(amount: u64) -> (Mint<ExposedSigner>, bls_dkg::outcome::Outcome, Dbc) {
     let genesis_owner = bls_dkg_id();
 
     let mut genesis_node = Mint::new(KeyManager::new(
-        genesis_owner.public_key_set.clone(),
-        (0, genesis_owner.secret_key_share.clone()),
+        ExposedSigner::new(
+            0,
+            genesis_owner.public_key_set.clone(),
+            genesis_owner.secret_key_share.clone(),
+        ),
         genesis_owner.public_key_set.public_key(),
     ));
 

--- a/src/dbc.rs
+++ b/src/dbc.rs
@@ -62,7 +62,7 @@ mod tests {
     use quickcheck_macros::quickcheck;
 
     use crate::tests::{NonZeroTinyInt, TinyInt};
-    use crate::{KeyManager, Mint, ReissueRequest, ReissueTransaction};
+    use crate::{ExposedSigner, KeyManager, Mint, ReissueRequest, ReissueTransaction};
 
     fn divide(amount: u64, n_ways: u8) -> impl Iterator<Item = u64> {
         (0..n_ways).into_iter().map(move |i| {
@@ -156,8 +156,11 @@ mod tests {
         let genesis_key = genesis_owner.public_key_set.public_key();
 
         let mut genesis_node = Mint::new(KeyManager::new(
-            genesis_owner.public_key_set.clone(),
-            (0, genesis_owner.secret_key_share.clone()),
+            ExposedSigner::new(
+                0,
+                genesis_owner.public_key_set.clone(),
+                genesis_owner.secret_key_share.clone(),
+            ),
             genesis_key,
         ));
 
@@ -298,8 +301,7 @@ mod tests {
             if let Some(input) = repeating_inputs.next() {
                 let id = crate::bls_dkg_id();
                 let key_mgr = KeyManager::new(
-                    id.public_key_set.clone(),
-                    (0, id.secret_key_share),
+                    ExposedSigner::new(0, id.public_key_set.clone(), id.secret_key_share.clone()),
                     genesis_key,
                 );
                 let trans_sig_share = key_mgr.sign(&transaction.hash());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,8 +27,11 @@ pub use crate::{
     dbc_content::{BlindedOwner, DbcContent},
     dbc_transaction::DbcTransaction,
     error::{Error, Result},
-    key_manager::{KeyCache, KeyManager, NodeSignature, PublicKey, PublicKeySet, Signature},
-    mint::{Mint, MintSignatures, ReissueRequest, ReissueTransaction, GENESIS_DBC_INPUT},
+    key_manager::{
+        ExposedSigner, KeyCache, KeyManager, NodeSignature, PublicKey, PublicKeySet, Signature,
+        Signer,
+    },
+    mint::{Mint, ReissueRequest, ReissueTransaction, GENESIS_DBC_INPUT},
 };
 
 impl From<[u8; 32]> for Hash {

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -14,8 +14,8 @@
 // Outputs <= input value
 
 use crate::{
-    Dbc, DbcContent, DbcContentHash, DbcTransaction, Error, Hash, KeyCache, KeyManager,
-    NodeSignature, PublicKeySet, Result,
+    key_manager::Signer, Dbc, DbcContent, DbcContentHash, DbcTransaction, Error, Hash, KeyCache,
+    KeyManager, NodeSignature, PublicKeySet, Result,
 };
 use serde::{Deserialize, Serialize};
 use std::{
@@ -123,13 +123,16 @@ pub struct ReissueRequest {
 }
 
 #[derive(Debug, Clone)]
-pub struct Mint {
-    pub(crate) key_mgr: KeyManager,
+pub struct Mint<S>
+where
+    S: Signer,
+{
+    pub(crate) key_mgr: KeyManager<S>,
     pub spendbook: SpendBook,
 }
 
-impl Mint {
-    pub fn new(key_mgr: KeyManager) -> Self {
+impl<S: Signer> Mint<S> {
+    pub fn new(key_mgr: KeyManager<S>) -> Self {
         Self {
             key_mgr,
             spendbook: Default::default(),
@@ -256,7 +259,10 @@ mod tests {
     use super::*;
     use quickcheck_macros::quickcheck;
 
-    use crate::tests::{TinyInt, TinyVec};
+    use crate::{
+        tests::{TinyInt, TinyVec},
+        ExposedSigner,
+    };
 
     #[quickcheck]
     fn prop_genesis() {
@@ -264,8 +270,11 @@ mod tests {
         let genesis_key = genesis_owner.public_key_set.public_key();
 
         let mut genesis_node = Mint::new(KeyManager::new(
-            genesis_owner.public_key_set,
-            (0, genesis_owner.secret_key_share),
+            ExposedSigner::new(
+                0,
+                genesis_owner.public_key_set.clone(),
+                genesis_owner.secret_key_share,
+            ),
             genesis_key,
         ));
 
@@ -298,8 +307,11 @@ mod tests {
         let genesis_owner = crate::bls_dkg_id();
         let genesis_key = genesis_owner.public_key_set.public_key();
         let mut genesis_node = Mint::new(KeyManager::new(
-            genesis_owner.public_key_set.clone(),
-            (0, genesis_owner.secret_key_share.clone()),
+            ExposedSigner::new(
+                0,
+                genesis_owner.public_key_set.clone(),
+                genesis_owner.secret_key_share.clone(),
+            ),
             genesis_key,
         ));
 
@@ -403,8 +415,11 @@ mod tests {
         let genesis_owner = crate::bls_dkg_id();
         let genesis_key = genesis_owner.public_key_set.public_key();
         let mut genesis_node = Mint::new(KeyManager::new(
-            genesis_owner.public_key_set,
-            (0, genesis_owner.secret_key_share),
+            ExposedSigner::new(
+                0,
+                genesis_owner.public_key_set.clone(),
+                genesis_owner.secret_key_share,
+            ),
             genesis_key,
         ));
 
@@ -530,8 +545,11 @@ mod tests {
         let genesis_owner = crate::bls_dkg_id();
         let genesis_key = genesis_owner.public_key_set.public_key();
         let mut genesis_node = Mint::new(KeyManager::new(
-            genesis_owner.public_key_set,
-            (0, genesis_owner.secret_key_share),
+            ExposedSigner::new(
+                0,
+                genesis_owner.public_key_set.clone(),
+                genesis_owner.secret_key_share,
+            ),
             genesis_key,
         ));
 
@@ -802,8 +820,11 @@ mod tests {
         let genesis_owner = crate::bls_dkg_id();
         let genesis_key = genesis_owner.public_key_set.public_key();
         let mut genesis_node = Mint::new(KeyManager::new(
-            genesis_owner.public_key_set,
-            (0, genesis_owner.secret_key_share),
+            ExposedSigner::new(
+                0,
+                genesis_owner.public_key_set.clone(),
+                genesis_owner.secret_key_share,
+            ),
             genesis_key,
         ));
 


### PR DESCRIPTION
This is because downstream consumer does not have access to secret key shares, and instead relies on a dependency to hold it and sign data for them.