### PR TITLE
chore: impl Debug for Hash to display hex encoded

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ quickcheck = "1"
 quickcheck_macros = "1"
 rand = "0.7.1"
 threshold_crypto = "0.4"
+hex = "0.4.3"
 
   [dependencies.bls_dkg]
   version = "~0.3.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,11 +8,12 @@
 #![allow(clippy::from_iter_instead_of_collect)]
 
 use serde::{Deserialize, Serialize};
+use std::fmt;
 use std::ops::Deref;
 #[cfg(test)]
 use tiny_keccak::{Hasher, Sha3};
 /// These typdefs are to simplify algorithm for now and will be removed for production.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Hash([u8; 32]);
 pub(crate) type DbcContentHash = Hash;
 mod dbc;
@@ -34,6 +35,14 @@ pub use crate::{
 impl From<[u8; 32]> for Hash {
     fn from(val: [u8; 32]) -> Hash {
         Hash(val)
+    }
+}
+
+// Display Hash value as hex in Debug output.  consolidates 36 lines to 3 for pretty output
+// and the hex value is the same as sn_dbc_mint display of DBC IDs.
+impl fmt::Debug for Hash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Hash").field(&hex::encode(self.0)).finish()
     }
 }
 


### PR DESCRIPTION
This makes debug output a lot more readable.  The sn_dbc_mint cli has a decode command for displaying various data structures using "{:#?}" formatting.  There might be several hashes in a single data structure.  Using default Debug formatting, each looks like:

```
       Hash(
            [
                141,
                146,
                235,
                200,
                252,
                24,
                79,
                186,
                2,
                53,
                69,
                190,
                237,
                247,
                68,
                201,
                27,
                75,
                211,
                232,
                22,
                39,
                167,
                33,
                77,
                84,
                92,
                118,
                173,
                113,
                225,
                99,
            ],
        )
```

Using the new formatting, each looks like:

```
        Hash(
            "8d92ebc8fc184fba023545beedf744c91b4bd3e81627a7214d545c76ad71e163",
        )
```

The hex encoded strings also match the display of DBC IDs in sn_dbc_mint output, so makes debug output easier to match up.