### PR TITLE
enables Mint to be Serializable, Deserializable

### DIFF
--- a/src/mint.rs
+++ b/src/mint.rs
@@ -27,7 +27,7 @@ pub type MintSignatures = BTreeMap<DbcContentHash, (PublicKeySet, NodeSignature)
 
 pub const GENESIS_DBC_INPUT: Hash = Hash([0u8; 32]);
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct SpendBook {
     pub transactions: BTreeMap<DbcContentHash, DbcTransaction>,
 }
@@ -122,7 +122,7 @@ pub struct ReissueRequest {
         HashMap<DbcContentHash, (threshold_crypto::PublicKey, threshold_crypto::Signature)>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Mint {
     pub(crate) key_mgr: KeyManager,
     pub spendbook: SpendBook,


### PR DESCRIPTION
This PR wraps SecretKeyShare with SerdeSecret, which enables it to be serialized, thus enabling Mint to be serialized, along with the spendbook.

I need the serialization in mint-cli example only until a better method is implemented for writing out spendbook and key data, which is supposed to be coming soon (tm).  Thus, it is not critical that this be merged.  But if it isn't, it blocks adding the mint-cli example until the better solution is impl'd.