### PR TITLE
refactor(signing): use keymanager trait instead of exposing secret ke…

### DIFF
--- a/benches/reissue.rs
+++ b/benches/reissue.rs
@@ -2,7 +2,6 @@
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::iter::FromIterator;
-use std::sync::Arc;
 
 use sn_dbc::{
     bls_dkg_id, Dbc, DbcContent, Mint, ReissueRequest, ReissueTransaction, SimpleKeyManager,
@@ -21,7 +20,7 @@ fn genesis(amount: u64) -> (Mint<SimpleKeyManager>, bls_dkg::outcome::Outcome, D
         ),
         genesis_owner.public_key_set.public_key(),
     );
-    let mut genesis_node = Mint::new(Arc::new(key_manager));
+    let mut genesis_node = Mint::new(key_manager);
 
     let (content, transaction, (mint_key_set, mint_sig_share)) =
         genesis_node.issue_genesis_dbc(amount).unwrap();

--- a/benches/reissue.rs
+++ b/benches/reissue.rs
@@ -2,19 +2,26 @@
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::iter::FromIterator;
+use std::sync::Arc;
 
-use sn_dbc::{bls_dkg_id, Dbc, DbcContent, KeyManager, Mint, ReissueRequest, ReissueTransaction};
+use sn_dbc::{
+    bls_dkg_id, Dbc, DbcContent, Mint, ReissueRequest, ReissueTransaction, SimpleKeyManager,
+    SimpleSigner,
+};
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
-fn genesis(amount: u64) -> (Mint, bls_dkg::outcome::Outcome, Dbc) {
+fn genesis(amount: u64) -> (Mint<SimpleKeyManager>, bls_dkg::outcome::Outcome, Dbc) {
     let genesis_owner = bls_dkg_id();
 
-    let mut genesis_node = Mint::new(KeyManager::new(
-        genesis_owner.public_key_set.clone(),
-        (0, genesis_owner.secret_key_share.clone()),
+    let key_manager = SimpleKeyManager::new(
+        SimpleSigner::new(
+            genesis_owner.public_key_set.clone(),
+            (0, genesis_owner.secret_key_share.clone()),
+        ),
         genesis_owner.public_key_set.public_key(),
-    ));
+    );
+    let mut genesis_node = Mint::new(Arc::new(key_manager));
 
     let (content, transaction, (mint_key_set, mint_sig_share)) =
         genesis_node.issue_genesis_dbc(amount).unwrap();

--- a/src/dbc.rs
+++ b/src/dbc.rs
@@ -384,13 +384,6 @@ mod tests {
                     dbc.transaction.inputs
                 );
             }
-            Err(Error::UnrecognisedAuthority) => {
-                assert!(n_wrong_signer_sigs.coerce::<u8>() > 0);
-                assert!(dbc
-                    .transaction_sigs
-                    .values()
-                    .any(|(k, _)| verifier.verify_known_key(k).is_err()));
-            }
             Err(Error::DbcContentParentsDifferentFromTransactionInputs) => {
                 assert!(
                     n_add_random_parents.coerce::<u8>() > 0 || n_drop_parents.coerce::<u8>() > 0
@@ -406,6 +399,23 @@ mod tests {
             }
             Err(Error::FailedSignature) => {
                 assert_ne!(n_wrong_msg_sigs.coerce::<u8>(), 0);
+            }
+            Err(Error::Signing(s)) if s == Error::FailedSignature.to_string() => {
+                assert_ne!(n_wrong_msg_sigs.coerce::<u8>(), 0);
+            }
+            Err(Error::UnrecognisedAuthority) => {
+                assert!(n_wrong_signer_sigs.coerce::<u8>() > 0);
+                assert!(dbc
+                    .transaction_sigs
+                    .values()
+                    .any(|(k, _)| verifier.verify_known_key(k).is_err()));
+            }
+            Err(Error::Signing(s)) if s == Error::UnrecognisedAuthority.to_string() => {
+                assert!(n_wrong_signer_sigs.coerce::<u8>() > 0);
+                assert!(dbc
+                    .transaction_sigs
+                    .values()
+                    .any(|(k, _)| verifier.verify_known_key(k).is_err()));
             }
             res => panic!("Unexpected verification result {:?}", res),
         }

--- a/src/dbc.rs
+++ b/src/dbc.rs
@@ -7,7 +7,8 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::{
-    DbcContent, DbcContentHash, DbcTransaction, Error, Hash, KeyCache, PublicKey, Result, Signature,
+    DbcContent, DbcContentHash, DbcTransaction, Error, Hash, KeyManager, PublicKey, Result,
+    Signature, Verifier,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -30,13 +31,13 @@ impl Dbc {
 
     // Check there exists a DbcTransaction with the output containing this Dbc
     // Check there DOES NOT exist a DbcTransaction with this Dbc as parent (already minted)
-    pub fn confirm_valid(&self, key_cache: &KeyCache) -> Result<(), Error> {
+    pub fn confirm_valid<K: KeyManager>(&self, verifier: &Verifier<K>) -> Result<(), Error> {
         for (input, (mint_key, mint_sig)) in self.transaction_sigs.iter() {
             if !self.transaction.inputs.contains(input) {
                 return Err(Error::UnknownInput);
             }
 
-            key_cache.verify(&self.transaction.hash(), &mint_key, &mint_sig)?;
+            verifier.verify(&self.transaction.hash(), &mint_key, &mint_sig)?;
         }
         if self.transaction.inputs.is_empty() {
             Err(Error::TransactionMustHaveAnInput)
@@ -58,11 +59,14 @@ mod tests {
 
     use std::collections::{BTreeSet, HashMap, HashSet};
     use std::iter::FromIterator;
+    use std::sync::Arc;
 
     use quickcheck_macros::quickcheck;
 
     use crate::tests::{NonZeroTinyInt, TinyInt};
-    use crate::{KeyManager, Mint, ReissueRequest, ReissueTransaction};
+    use crate::{
+        KeyManager, Mint, ReissueRequest, ReissueTransaction, SimpleKeyManager, SimpleSigner,
+    };
 
     fn divide(amount: u64, n_ways: u8) -> impl Iterator<Item = u64> {
         (0..n_ways).into_iter().map(move |i| {
@@ -133,8 +137,14 @@ mod tests {
             transaction_sigs: Default::default(),
         };
 
+        let id = crate::bls_dkg_id();
+        let key_manager = SimpleKeyManager::new(
+            SimpleSigner::new(id.public_key_set.clone(), (0, id.secret_key_share.clone())),
+            id.public_key_set.public_key(),
+        );
+
         assert!(matches!(
-            dbc.confirm_valid(&KeyCache::default()),
+            dbc.confirm_valid(&Verifier::new(Arc::new(key_manager))),
             Err(Error::TransactionMustHaveAnInput)
         ));
     }
@@ -155,11 +165,14 @@ mod tests {
         let genesis_owner = crate::bls_dkg_id();
         let genesis_key = genesis_owner.public_key_set.public_key();
 
-        let mut genesis_node = Mint::new(KeyManager::new(
-            genesis_owner.public_key_set.clone(),
-            (0, genesis_owner.secret_key_share.clone()),
-            genesis_key,
-        ));
+        let key_manager = SimpleKeyManager::new(
+            SimpleSigner::new(
+                genesis_owner.public_key_set.clone(),
+                (0, genesis_owner.secret_key_share.clone()),
+            ),
+            genesis_owner.public_key_set.public_key(),
+        );
+        let mut genesis_node = Mint::new(Arc::new(key_manager));
 
         let (gen_dbc_content, gen_dbc_trans, (gen_key_set, gen_node_sig)) =
             genesis_node.issue_genesis_dbc(amount).unwrap();
@@ -297,12 +310,11 @@ mod tests {
         for _ in 0..n_wrong_signer_sigs.coerce() {
             if let Some(input) = repeating_inputs.next() {
                 let id = crate::bls_dkg_id();
-                let key_mgr = KeyManager::new(
-                    id.public_key_set.clone(),
-                    (0, id.secret_key_share),
+                let key_manager = SimpleKeyManager::new(
+                    SimpleSigner::new(id.public_key_set.clone(), (0, id.secret_key_share.clone())),
                     genesis_key,
                 );
-                let trans_sig_share = key_mgr.sign(&transaction.hash());
+                let trans_sig_share = key_manager.sign(&transaction.hash());
                 let trans_sig = id
                     .public_key_set
                     .combine_signatures(vec![trans_sig_share.threshold_crypto()])
@@ -315,9 +327,9 @@ mod tests {
         // Valid mint signatures BUT signing wrong message
         for _ in 0..n_wrong_msg_sigs.coerce() {
             if let Some(input) = repeating_inputs.next() {
-                let wrong_msg_sig = genesis_node.key_mgr.sign(&Hash([0u8; 32]));
+                let wrong_msg_sig = genesis_node.key_manager.sign(&Hash([0u8; 32]));
                 let wrong_msg_mint_sig = genesis_node
-                    .key_mgr
+                    .key_manager
                     .public_key_set()
                     .combine_signatures(vec![wrong_msg_sig.threshold_crypto()])
                     .unwrap();
@@ -337,8 +349,13 @@ mod tests {
             transaction_sigs: fuzzed_transaction_sigs,
         };
 
-        let key_cache = KeyCache::from(vec![genesis_key]);
-        let validation_res = dbc.confirm_valid(&key_cache);
+        let id = crate::bls_dkg_id();
+        let key_manager = SimpleKeyManager::new(
+            SimpleSigner::new(id.public_key_set.clone(), (0, id.secret_key_share)),
+            genesis_key,
+        );
+        let verifier = Verifier::new(Arc::new(key_manager));
+        let validation_res = dbc.confirm_valid(&verifier);
 
         println!("Validation Result: {:#?}", validation_res);
         match validation_res {
@@ -369,7 +386,7 @@ mod tests {
                 assert!(dbc
                     .transaction_sigs
                     .values()
-                    .any(|(k, _)| key_cache.verify_known_key(k).is_err()));
+                    .any(|(k, _)| verifier.verify_known_key(k).is_err()));
             }
             Err(Error::DbcContentParentsDifferentFromTransactionInputs) => {
                 assert!(

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,7 +17,8 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 #[non_exhaustive]
 /// Node error variants.
 pub enum Error {
-    /// Attempted to perform an operation meant only for Adults when we are not one.
+    #[error("An error occured when signing {0}")]
+    Signing(String),
     #[error("Attempted an invalid operation {0}")]
     InvalidOperation(String),
     #[error("This input has a signature, but it doesn't appear in the transaction")]

--- a/src/key_manager.rs
+++ b/src/key_manager.rs
@@ -8,7 +8,7 @@
 
 use crate::{Error, Hash, Result};
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::{collections::HashSet, sync::Arc};
 use threshold_crypto::{serde_impl::SerdeSecret, SecretKeyShare, SignatureShare};
 pub use threshold_crypto::{PublicKey, PublicKeySet, Signature};
 
@@ -21,11 +21,122 @@ impl NodeSignature {
     }
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
-pub struct KeyCache(HashSet<PublicKey>);
+pub trait KeyManager {
+    fn sign(&self, msg_hash: &Hash) -> NodeSignature;
+    fn verify_we_are_a_genesis_node(&self) -> Result<()>;
+    fn public_key_set(&self) -> PublicKeySet;
+    fn verify(&self, msg_hash: &Hash, key: &PublicKey, signature: &Signature) -> Result<()>;
+    fn verify_known_key(&self, key: &PublicKey) -> Result<()>;
+}
 
-impl KeyCache {
+#[derive(Debug, Clone)]
+pub struct Verifier<K: KeyManager> {
+    key_manager: Arc<K>,
+}
+
+impl<K: KeyManager> Verifier<K> {
+    pub fn new(key_manager: Arc<K>) -> Self {
+        Self { key_manager }
+    }
+
     pub fn verify(&self, msg: &Hash, key: &PublicKey, sig: &Signature) -> Result<()> {
+        self.key_manager.verify(msg, key, sig)
+    }
+
+    pub fn verify_known_key(&self, key: &PublicKey) -> Result<()> {
+        self.key_manager.verify_known_key(key)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SimpleSigner {
+    public_key_set: PublicKeySet,
+    secret_key_share: (u64, SerdeSecret<SecretKeyShare>),
+}
+
+impl SimpleSigner {
+    pub fn new(public_key_set: PublicKeySet, secret_key_share: (u64, SecretKeyShare)) -> Self {
+        Self {
+            public_key_set,
+            secret_key_share: (secret_key_share.0, SerdeSecret(secret_key_share.1)),
+        }
+    }
+
+    fn index(&self) -> u64 {
+        self.secret_key_share.0
+    }
+
+    fn public_key_set(&self) -> PublicKeySet {
+        self.public_key_set.clone()
+    }
+
+    fn sign<M: AsRef<[u8]>>(&self, msg: M) -> threshold_crypto::SignatureShare {
+        self.secret_key_share.1.sign(msg)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SimpleKeyManager {
+    signer: SimpleSigner,
+    genesis_key: PublicKey,
+    cache: Keys,
+}
+
+impl SimpleKeyManager {
+    pub fn new(signer: SimpleSigner, genesis_key: PublicKey) -> Self {
+        let public_key_set = signer.public_key_set();
+        let mut cache = Keys::default();
+        cache.add_known_key(genesis_key);
+        cache.add_known_key(public_key_set.public_key());
+        Self {
+            signer,
+            genesis_key,
+            cache,
+        }
+    }
+}
+
+impl KeyManager for SimpleKeyManager {
+    fn verify_we_are_a_genesis_node(&self) -> Result<()> {
+        if self.signer.public_key_set().public_key() == self.genesis_key {
+            Ok(())
+        } else {
+            Err(Error::NotGenesisNode)
+        }
+    }
+
+    fn public_key_set(&self) -> PublicKeySet {
+        self.signer.public_key_set()
+    }
+
+    fn sign(&self, msg_hash: &Hash) -> NodeSignature {
+        NodeSignature(self.signer.index(), self.signer.sign(msg_hash))
+    }
+
+    fn verify(&self, msg_hash: &Hash, key: &PublicKey, signature: &Signature) -> Result<()> {
+        self.cache.verify(msg_hash, key, signature)
+    }
+
+    fn verify_known_key(&self, key: &PublicKey) -> Result<()> {
+        self.cache.verify_known_key(key)
+    }
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+struct Keys(HashSet<PublicKey>);
+
+impl From<Vec<PublicKey>> for Keys {
+    fn from(keys: Vec<PublicKey>) -> Self {
+        Self(keys.into_iter().collect())
+    }
+}
+
+impl Keys {
+    pub fn add_known_key(&mut self, key: PublicKey) {
+        self.0.insert(key);
+    }
+
+    fn verify(&self, msg: &Hash, key: &PublicKey, sig: &Signature) -> Result<()> {
         self.verify_known_key(key)?;
         if key.verify(&sig, msg) {
             Ok(())
@@ -34,78 +145,11 @@ impl KeyCache {
         }
     }
 
-    pub fn verify_known_key(&self, key: &PublicKey) -> Result<()> {
+    fn verify_known_key(&self, key: &PublicKey) -> Result<()> {
         if self.0.contains(key) {
             Ok(())
         } else {
             Err(Error::UnrecognisedAuthority)
         }
-    }
-
-    pub fn add_known_key(&mut self, key: PublicKey) {
-        self.0.insert(key);
-    }
-}
-
-impl From<Vec<PublicKey>> for KeyCache {
-    fn from(keys: Vec<PublicKey>) -> Self {
-        Self(keys.into_iter().collect())
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct KeyManager {
-    public_key_set: PublicKeySet,
-    secret_key_share: (u64, SerdeSecret<SecretKeyShare>),
-    genesis_key: PublicKey,
-    cache: KeyCache,
-}
-
-impl KeyManager {
-    pub fn new(
-        public_key_set: PublicKeySet,
-        secret_key_share: (u64, SecretKeyShare),
-        genesis_key: PublicKey,
-    ) -> Self {
-        let mut cache = KeyCache::default();
-        cache.add_known_key(genesis_key);
-        cache.add_known_key(public_key_set.public_key());
-        Self {
-            public_key_set,
-            secret_key_share: (secret_key_share.0, SerdeSecret(secret_key_share.1)),
-            genesis_key,
-            cache,
-        }
-    }
-
-    pub fn verify_we_are_a_genesis_node(&self) -> Result<()> {
-        if self.public_key_set.public_key() == self.genesis_key {
-            Ok(())
-        } else {
-            Err(Error::NotGenesisNode)
-        }
-    }
-
-    pub fn key_cache(&self) -> &KeyCache {
-        &self.cache
-    }
-
-    pub fn public_key_set(&self) -> PublicKeySet {
-        self.public_key_set.clone()
-    }
-
-    pub fn secret_key_share(&self) -> SecretKeyShare {
-        self.secret_key_share.1.inner().clone()
-    }
-
-    pub fn sign(&self, msg_hash: &Hash) -> NodeSignature {
-        NodeSignature(
-            self.secret_key_share.0,
-            self.secret_key_share.1.inner().sign(msg_hash),
-        )
-    }
-
-    pub fn verify(&self, msg_hash: &Hash, key: &PublicKey, signature: &Signature) -> Result<()> {
-        self.cache.verify(msg_hash, key, signature)
     }
 }

--- a/src/key_manager.rs
+++ b/src/key_manager.rs
@@ -8,7 +8,7 @@
 
 use crate::{Error, Hash, Result};
 use serde::{Deserialize, Serialize};
-use std::{collections::HashSet, sync::Arc};
+use std::collections::HashSet;
 use threshold_crypto::{serde_impl::SerdeSecret, SecretKeyShare, SignatureShare};
 pub use threshold_crypto::{PublicKey, PublicKeySet, Signature};
 
@@ -39,30 +39,6 @@ pub trait KeyManager {
         signature: &Signature,
     ) -> Result<(), Self::Error>;
     fn verify_known_key(&self, key: &PublicKey) -> Result<(), Self::Error>;
-}
-
-#[derive(Debug, Clone)]
-pub struct Verifier<K: KeyManager> {
-    key_manager: Arc<K>,
-}
-
-impl<K: KeyManager> Verifier<K> {
-    pub fn new(key_manager: Arc<K>) -> Self {
-        Self { key_manager }
-    }
-
-    pub fn verify(
-        &self,
-        msg: &Hash,
-        key: &PublicKey,
-        sig: &Signature,
-    ) -> Result<(), <K as KeyManager>::Error> {
-        self.key_manager.verify(msg, key, sig)
-    }
-
-    pub fn verify_known_key(&self, key: &PublicKey) -> Result<(), <K as KeyManager>::Error> {
-        self.key_manager.verify_known_key(key)
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,10 @@ pub use crate::{
     dbc_content::{BlindedOwner, DbcContent},
     dbc_transaction::DbcTransaction,
     error::{Error, Result},
-    key_manager::{KeyCache, KeyManager, NodeSignature, PublicKey, PublicKeySet, Signature},
+    key_manager::{
+        KeyManager, NodeSignature, PublicKey, PublicKeySet, Signature, SimpleKeyManager,
+        SimpleSigner, Verifier,
+    },
     mint::{Mint, MintSignatures, ReissueRequest, ReissueTransaction, GENESIS_DBC_INPUT},
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ pub use crate::{
     error::{Error, Result},
     key_manager::{
         KeyManager, NodeSignature, PublicKey, PublicKeySet, Signature, SimpleKeyManager,
-        SimpleSigner, Verifier,
+        SimpleSigner,
     },
     mint::{Mint, MintSignatures, ReissueRequest, ReissueTransaction, GENESIS_DBC_INPUT},
 };


### PR DESCRIPTION
…y share
Required by downstream sn consumer.