### PR TITLE
make SpendBook a trait so that implementer can decide how to store it

### DIFF
--- a/benches/reissue.rs
+++ b/benches/reissue.rs
@@ -5,12 +5,18 @@ use std::iter::FromIterator;
 
 use sn_dbc::{
     bls_dkg_id, Dbc, DbcContent, Mint, ReissueRequest, ReissueTransaction, SimpleKeyManager,
-    SimpleSigner,
+    SimpleSigner, SimpleSpendBook,
 };
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
-fn genesis(amount: u64) -> (Mint<SimpleKeyManager>, bls_dkg::outcome::Outcome, Dbc) {
+fn genesis(
+    amount: u64,
+) -> (
+    Mint<SimpleKeyManager, SimpleSpendBook>,
+    bls_dkg::outcome::Outcome,
+    Dbc,
+) {
     let genesis_owner = bls_dkg_id();
 
     let key_manager = SimpleKeyManager::new(
@@ -20,7 +26,7 @@ fn genesis(amount: u64) -> (Mint<SimpleKeyManager>, bls_dkg::outcome::Outcome, D
         ),
         genesis_owner.public_key_set.public_key(),
     );
-    let mut genesis_node = Mint::new(key_manager);
+    let mut genesis_node = Mint::new(key_manager, SimpleSpendBook::new());
 
     let (content, transaction, (mint_key_set, mint_sig_share)) =
         genesis_node.issue_genesis_dbc(amount).unwrap();

--- a/examples/mint-repl/mint-repl.rs
+++ b/examples/mint-repl/mint-repl.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 use sn_dbc::{
     BlindedOwner, Dbc, DbcContent, DbcTransaction, Hash, Mint, MintSignatures, NodeSignature,
     ReissueRequest, ReissueTransaction, SimpleKeyManager as KeyManager, SimpleSigner as Signer,
-    SimpleSpendBook as SpendBook,
+    SimpleSpendBook as SpendBook, SpendBook as SpendBookTrait,
 };
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::iter::FromIterator;
@@ -360,7 +360,7 @@ fn print_mintinfo_human(mintinfo: &MintInfo) -> Result<()> {
     println!("\n");
 
     println!("-- SpendBook --\n");
-    for (dbchash, _tx) in mintinfo.mintnode()?.spendbook.transactions.iter() {
+    for (dbchash, _tx) in mintinfo.mintnode()?.spendbook.entries() {
         println!("  {}", encode(&dbchash));
     }
 

--- a/examples/mint-repl/mint-repl.rs
+++ b/examples/mint-repl/mint-repl.rs
@@ -499,7 +499,7 @@ fn validate(mintinfo: &MintInfo) -> Result<()> {
     };
 
     match dbc.confirm_valid(mintinfo.mintnode()?.key_manager()) {
-        Ok(_) => match mintinfo.mintnode()?.is_spent(dbc.name()) {
+        Ok(_) => match mintinfo.mintnode()?.is_spent(dbc.name())? {
             true => println!("\nThis DBC is unspendable.  (valid but has already been spent)\n"),
             false => println!("\nThis DBC is spendable.   (valid and has not been spent)\n"),
         },

--- a/src/dbc.rs
+++ b/src/dbc.rs
@@ -67,6 +67,7 @@ mod tests {
     use crate::tests::{NonZeroTinyInt, TinyInt};
     use crate::{
         KeyManager, Mint, ReissueRequest, ReissueTransaction, SimpleKeyManager, SimpleSigner,
+        SimpleSpendBook,
     };
 
     fn divide(amount: u64, n_ways: u8) -> impl Iterator<Item = u64> {
@@ -173,7 +174,7 @@ mod tests {
             ),
             genesis_owner.public_key_set.public_key(),
         );
-        let mut genesis_node = Mint::new(key_manager);
+        let mut genesis_node = Mint::new(key_manager, SimpleSpendBook::new());
 
         let (gen_dbc_content, gen_dbc_trans, (gen_key_set, gen_node_sig)) =
             genesis_node.issue_genesis_dbc(amount).unwrap();

--- a/src/error.rs
+++ b/src/error.rs
@@ -61,4 +61,6 @@ pub enum Error {
     /// JSON serialisation error.
     #[error("JSON serialisation error:: {0}")]
     JsonSerialisation(#[from] serde_json::Error),
+    #[error("SpendBook error {0}")]
+    SpendBook(String),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,10 @@ pub use crate::{
         KeyManager, NodeSignature, PublicKey, PublicKeySet, Signature, SimpleKeyManager,
         SimpleSigner,
     },
-    mint::{Mint, MintSignatures, ReissueRequest, ReissueTransaction, GENESIS_DBC_INPUT},
+    mint::{
+        Mint, MintSignatures, ReissueRequest, ReissueTransaction, SimpleSpendBook, SpendBook,
+        GENESIS_DBC_INPUT,
+    },
 };
 
 impl From<[u8; 32]> for Hash {

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -27,7 +27,7 @@ pub type MintSignatures = BTreeMap<DbcContentHash, (PublicKeySet, NodeSignature)
 
 pub const GENESIS_DBC_INPUT: Hash = Hash([0u8; 32]);
 
-pub trait SpendBook: std::fmt::Debug + Clone + IntoIterator {
+pub trait SpendBook: std::fmt::Debug + Clone {
     type Error: std::error::Error;
 
     fn lookup(&self, dbc_hash: &DbcContentHash) -> Result<Option<&DbcTransaction>, Self::Error>;
@@ -36,6 +36,8 @@ pub trait SpendBook: std::fmt::Debug + Clone + IntoIterator {
         dbc_hash: DbcContentHash,
         transaction: DbcTransaction,
     ) -> Result<(), Self::Error>;
+
+    fn entries(&self) -> Box<dyn Iterator<Item = (&DbcContentHash, &DbcTransaction)> + '_>;
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
@@ -58,14 +60,9 @@ impl SpendBook for SimpleSpendBook {
         self.transactions.insert(dbc_hash, transaction);
         Ok(())
     }
-}
 
-impl IntoIterator for SimpleSpendBook {
-    type Item = (DbcContentHash, DbcTransaction);
-    type IntoIter = std::collections::btree_map::IntoIter<DbcContentHash, DbcTransaction>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.transactions.into_iter()
+    fn entries(&self) -> Box<dyn Iterator<Item = (&DbcContentHash, &DbcTransaction)> + '_> {
+        Box::new(self.transactions.iter())
     }
 }
 


### PR DESCRIPTION
first cut at this.

I made IntoIterator a supertrait of SpendBook trait to provide/require a mechanism for reading all the spendbook entries.   I'm not sure if there is any way to enforce that implementer's actually return a DbcTransaction when iterating though... seems they could return any type they wish.  any suggestions?

Also, I wanted to name the default SpendBook impl `SpendBookRam` as it seems more descriptive.  But I went with `SimpleSpendBook` for symmetry with the other traits.

Also, I snuck in a tiny fix for mint-repl `newmint` command.