### PR TITLE
require IntoIterator<Item = (DbcContentHash, DbcTransaction)> for SpendBook trait

### DIFF
--- a/examples/mint-repl/mint-repl.rs
+++ b/examples/mint-repl/mint-repl.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 use sn_dbc::{
     BlindedOwner, Dbc, DbcContent, DbcTransaction, Hash, Mint, MintSignatures, NodeSignature,
     ReissueRequest, ReissueTransaction, SimpleKeyManager as KeyManager, SimpleSigner as Signer,
-    SimpleSpendBook as SpendBook, SpendBook as SpendBookTrait,
+    SimpleSpendBook as SpendBook,
 };
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::iter::FromIterator;
@@ -358,7 +358,7 @@ fn print_mintinfo_human(mintinfo: &MintInfo) -> Result<()> {
     println!("\n");
 
     println!("-- SpendBook --\n");
-    for (dbchash, _tx) in mintinfo.mintnode()?.spendbook.entries() {
+    for (dbchash, _tx) in &mintinfo.mintnode()?.spendbook {
         println!("  {}", encode(&dbchash));
     }
 

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -27,9 +27,7 @@ pub type MintSignatures = BTreeMap<DbcContentHash, (PublicKeySet, NodeSignature)
 
 pub const GENESIS_DBC_INPUT: Hash = Hash([0u8; 32]);
 
-pub trait SpendBook:
-    std::fmt::Debug + Clone + IntoIterator<Item = (DbcContentHash, DbcTransaction)>
-{
+pub trait SpendBook: std::fmt::Debug + Clone {
     type Error: std::error::Error;
 
     fn lookup(&self, dbc_hash: &DbcContentHash) -> Result<Option<&DbcTransaction>, Self::Error>;


### PR DESCRIPTION
another attempt to require IntoIterator for SpendBook trait, to make usage more idiomatic and eliminate Box.

I figured out i could constrain the IntoIterator supertrait by specifying Item=<(x,y)>.  So that works well.

We'd also like to be able to iterate over a spendbook reference.  To that end, I impl'd IntoIterator for &SimpleSpendBook.  That works fine.

However, I wasn't able to require IntoIterator supertrait where Item=<(&x, &y)>.  When I try this I get into lifetime hell and compiler seems to want lifetimes on all parent structs, eg KeyManager, Mint, etc which I wasn't willing to do, and also I'm nearing limits of my Rust understanding.  So hopefully there is a simple solution I am missing...?

For now I left it that the SpendBook trait itself only requires IntoIterator(x,y).   SimpleSpendBook also impls IntoIterator(&x, &y), which is what mint-repl example uses to avoid a spendbook.clone() in for loop.

I think this PR should not be merged until the above is resolved satisfactorily.  Because it should not be necessary to consume/clone spendbook to iterate over it, so we should require that trait implementers also impl the by-ref version, as SimpleSpendBook does.

suggestions?