### PR TITLE
Outcome::index instead of 0; update dbc.rs tests to use transaction builder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ hex = "0.4.3"
   version = "0.8.0"
 
   [dependencies.bls_dkg]
-  version = "~0.5"
+  version = "~0.6"
   optional = true
 
   [dependencies.tiny-keccak]

--- a/src/dbc.rs
+++ b/src/dbc.rs
@@ -100,7 +100,7 @@ mod tests {
 
         let sig = dbc_owner
             .public_key_set
-            .combine_signatures(vec![(0, &sig_share)])
+            .combine_signatures(vec![(dbc_owner.index, &sig_share)])
             .unwrap();
 
         let dbc_owner_key = dbc_owner.public_key_set.public_key();
@@ -135,7 +135,7 @@ mod tests {
 
         let id = crate::bls_dkg_id();
         let key_manager = SimpleKeyManager::new(
-            SimpleSigner::new(id.public_key_set.clone(), (0, id.secret_key_share.clone())),
+            SimpleSigner::from(id.clone()),
             id.public_key_set.public_key(),
         );
 
@@ -164,10 +164,7 @@ mod tests {
         let genesis_key = genesis_owner.public_key_set.public_key();
 
         let key_manager = SimpleKeyManager::new(
-            SimpleSigner::new(
-                genesis_owner.public_key_set.clone(),
-                (0, genesis_owner.secret_key_share.clone()),
-            ),
+            SimpleSigner::from(genesis_owner.clone()),
             genesis_owner.public_key_set.public_key(),
         );
         let mut genesis_node = Mint::new(key_manager, SimpleSpendBook::new());
@@ -243,7 +240,7 @@ mod tests {
 
         let input_owner_key_set = input_owner.public_key_set.clone();
         let sig = input_owner_key_set
-            .combine_signatures(vec![(0, &sig_share)])
+            .combine_signatures(vec![(input_owner.index, &sig_share)])
             .unwrap();
 
         let input_ownership_proofs = HashMap::from_iter(reissue_tx.inputs.iter().map(|input| {
@@ -313,10 +310,8 @@ mod tests {
         for _ in 0..n_wrong_signer_sigs.coerce() {
             if let Some(input) = repeating_inputs.next() {
                 let id = crate::bls_dkg_id();
-                let key_manager = SimpleKeyManager::new(
-                    SimpleSigner::new(id.public_key_set.clone(), (0, id.secret_key_share.clone())),
-                    genesis_key,
-                );
+                let key_manager =
+                    SimpleKeyManager::new(SimpleSigner::from(id.clone()), genesis_key);
                 let trans_sig_share = key_manager.sign(&transaction.hash()).unwrap();
                 let trans_sig = id
                     .public_key_set
@@ -354,10 +349,7 @@ mod tests {
         };
 
         let id = crate::bls_dkg_id();
-        let key_manager = SimpleKeyManager::new(
-            SimpleSigner::new(id.public_key_set.clone(), (0, id.secret_key_share)),
-            genesis_key,
-        );
+        let key_manager = SimpleKeyManager::new(SimpleSigner::from(id), genesis_key);
         let validation_res = dbc.confirm_valid(&key_manager);
 
         let dbc_amount = DbcHelper::decrypt_amount(&input_owner, &dbc.content)?;

--- a/src/dbc.rs
+++ b/src/dbc.rs
@@ -85,7 +85,7 @@ mod tests {
         let amount_secrets = DbcHelper::decrypt_amount_secrets(dbc_owner, &dbc.content)?;
 
         let (reissue_tx, _) = crate::TransactionBuilder::default()
-            .add_input(dbc.clone(), amount_secrets.clone())
+            .add_input(dbc.clone(), amount_secrets)
             .add_outputs(
                 divide(amount_secrets.amount, n_ways).map(|amount| crate::Output {
                     amount,

--- a/src/dbc_content.rs
+++ b/src/dbc_content.rs
@@ -52,7 +52,7 @@ impl BlindedOwner {
 
 /// Contains amount and Pedersen Commitment blinding factor which
 /// must be kept secret (encrypted) in the DBC.
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, Serialize, Deserialize)]
 pub struct AmountSecrets {
     pub amount: Amount,
     pub blinding_factor: Scalar,

--- a/src/key_manager.rs
+++ b/src/key_manager.rs
@@ -47,6 +47,16 @@ pub struct SimpleSigner {
     secret_key_share: (u64, SerdeSecret<SecretKeyShare>),
 }
 
+#[cfg(feature = "dkg")]
+impl From<bls_dkg::outcome::Outcome> for SimpleSigner {
+    fn from(outcome: bls_dkg::outcome::Outcome) -> Self {
+        Self {
+            public_key_set: outcome.public_key_set,
+            secret_key_share: (outcome.index as u64, SerdeSecret(outcome.secret_key_share)),
+        }
+    }
+}
+
 impl SimpleSigner {
     pub fn new(public_key_set: PublicKeySet, secret_key_share: (u64, SecretKeyShare)) -> Self {
         Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@ impl DbcHelper {
     ) -> Result<AmountSecrets, Error> {
         let mut shares: std::collections::BTreeMap<usize, bls_dkg::SecretKeyShare> =
             Default::default();
-        shares.insert(0, owner.secret_key_share.clone());
+        shares.insert(owner.index, owner.secret_key_share.clone());
 
         dbcc.amount_secrets_by_secret_key_shares(&owner.public_key_set, &shares)
     }

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -552,7 +552,7 @@ mod tests {
 
         let output_owner = crate::bls_dkg_id();
         let (reissue_tx, _output_owners) = crate::TransactionBuilder::default()
-            .add_input(genesis_dbc.clone(), genesis_amount_secrets.clone())
+            .add_input(genesis_dbc.clone(), genesis_amount_secrets)
             .add_output(crate::Output {
                 amount: 1000,
                 owner: output_owner.public_key_set.public_key(),
@@ -1174,7 +1174,7 @@ mod tests {
         let input_secrets = DbcHelper::decrypt_amount_secrets(&outputs_owner, &input_dbc.content)?;
 
         let (transaction, _) = crate::TransactionBuilder::default()
-            .add_input(input_dbc.clone(), input_secrets.clone())
+            .add_input(input_dbc.clone(), input_secrets)
             .add_output(crate::Output {
                 amount: input_secrets.amount,
                 owner: outputs_owner_pk,

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -366,10 +366,7 @@ mod tests {
         let genesis_key = genesis_owner.public_key_set.public_key();
 
         let key_manager = SimpleKeyManager::new(
-            SimpleSigner::new(
-                genesis_owner.public_key_set.clone(),
-                (0, genesis_owner.secret_key_share.clone()),
-            ),
+            SimpleSigner::from(genesis_owner.clone()),
             genesis_owner.public_key_set.public_key(),
         );
         let mut genesis_node = Mint::new(key_manager, SimpleSpendBook::new());
@@ -408,13 +405,8 @@ mod tests {
 
         let genesis_owner = crate::bls_dkg_id();
         let genesis_key = genesis_owner.public_key_set.public_key();
-        let key_manager = SimpleKeyManager::new(
-            SimpleSigner::new(
-                genesis_owner.public_key_set.clone(),
-                (0, genesis_owner.secret_key_share.clone()),
-            ),
-            genesis_key,
-        );
+        let key_manager =
+            SimpleKeyManager::new(SimpleSigner::from(genesis_owner.clone()), genesis_key);
         let mut genesis_node = Mint::new(key_manager.clone(), SimpleSpendBook::new());
 
         let (gen_dbc_content, gen_dbc_tx, (gen_key_set, gen_node_sig)) =
@@ -451,7 +443,7 @@ mod tests {
 
         let sig = genesis_owner
             .public_key_set
-            .combine_signatures(vec![(0, &sig_share)])?;
+            .combine_signatures(vec![(genesis_owner.index, &sig_share)])?;
 
         let reissue_req = ReissueRequest {
             transaction: reissue_tx,
@@ -524,13 +516,8 @@ mod tests {
     fn test_double_spend_protection() -> Result<()> {
         let genesis_owner = crate::bls_dkg_id();
         let genesis_key = genesis_owner.public_key_set.public_key();
-        let key_manager = SimpleKeyManager::new(
-            SimpleSigner::new(
-                genesis_owner.public_key_set.clone(),
-                (0, genesis_owner.secret_key_share.clone()),
-            ),
-            genesis_key,
-        );
+        let key_manager =
+            SimpleKeyManager::new(SimpleSigner::from(genesis_owner.clone()), genesis_key);
         let mut genesis_node = Mint::new(key_manager, SimpleSpendBook::new());
 
         let (gen_dbc_content, gen_dbc_tx, (gen_key_set, gen_node_sig)) =
@@ -648,10 +635,7 @@ mod tests {
         let genesis_owner = crate::bls_dkg_id();
         let genesis_key = genesis_owner.public_key_set.public_key();
         let key_manager = SimpleKeyManager::new(
-            SimpleSigner::new(
-                genesis_owner.public_key_set.clone(),
-                (0, genesis_owner.secret_key_share.clone()),
-            ),
+            SimpleSigner::from(genesis_owner.clone()),
             genesis_owner.public_key_set.public_key(),
         );
         let mut genesis_node = Mint::new(key_manager, SimpleSpendBook::new());
@@ -787,7 +771,7 @@ mod tests {
                 let owner = &owners[&dbc.name()];
                 let sig_share = owner.secret_key_share.sign(&reissue_tx.blinded().hash());
                 let owner_key_set = &owner.public_key_set;
-                let sig = owner_key_set.combine_signatures(vec![(0, &sig_share)])?;
+                let sig = owner_key_set.combine_signatures(vec![(owner.index, &sig_share)])?;
                 Ok((dbc.name(), (owner_key_set.public_key(), sig)))
             })
             .collect::<Result<HashMap<_, _>, Error>>()?;
@@ -801,7 +785,8 @@ mod tests {
                     .secret_key_share
                     .sign(&reissue_tx.blinded().hash());
                 let owner_key_set = random_owner.public_key_set;
-                let sig = owner_key_set.combine_signatures(vec![(0, &sig_share)])?;
+                let sig =
+                    owner_key_set.combine_signatures(vec![(random_owner.index, &sig_share)])?;
 
                 Ok((dbc.name(), (owner_key_set.public_key(), sig)))
             })
@@ -937,10 +922,7 @@ mod tests {
     fn test_inputs_are_validated() -> Result<(), Error> {
         let genesis_owner = crate::bls_dkg_id();
         let key_manager = SimpleKeyManager::new(
-            SimpleSigner::new(
-                genesis_owner.public_key_set.clone(),
-                (0, genesis_owner.secret_key_share.clone()),
-            ),
+            SimpleSigner::from(genesis_owner.clone()),
             genesis_owner.public_key_set.public_key(),
         );
         let mut genesis_node = Mint::new(key_manager, SimpleSpendBook::new());
@@ -1010,10 +992,7 @@ mod tests {
         let genesis_key = genesis_owner.public_key_set.public_key();
 
         let key_manager = SimpleKeyManager::new(
-            SimpleSigner::new(
-                genesis_owner.public_key_set.clone(),
-                (0, genesis_owner.secret_key_share.clone()),
-            ),
+            SimpleSigner::from(genesis_owner.clone()),
             genesis_owner.public_key_set.public_key(),
         );
         let mut genesis_node = Mint::new(key_manager.clone(), SimpleSpendBook::new());
@@ -1187,7 +1166,7 @@ mod tests {
 
         let sig = outputs_owner
             .public_key_set
-            .combine_signatures(vec![(0, &sig_share)])?;
+            .combine_signatures(vec![(outputs_owner.index, &sig_share)])?;
 
         let reissue_req = ReissueRequest {
             transaction,
@@ -1222,7 +1201,7 @@ mod tests {
 
         let sig = outputs_owner
             .public_key_set
-            .combine_signatures(vec![(0, &sig_share)])?;
+            .combine_signatures(vec![(outputs_owner.index, &sig_share)])?;
 
         let reissue_req = ReissueRequest {
             transaction,


### PR DESCRIPTION
We hard code 0 as the share index in our uses, bls_dkg 0.6 now has a `index` field on the Outcome struct.

Also fixes #79 