### PR TITLE
creates type alias Amount to use in place of u64

### DIFF
--- a/benches/reissue.rs
+++ b/benches/reissue.rs
@@ -4,8 +4,8 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::iter::FromIterator;
 
 use sn_dbc::{
-    bls_dkg_id, AmountSecrets, Dbc, DbcContent, Error, Mint, ReissueRequest, SimpleKeyManager,
-    SimpleSigner, SimpleSpendBook,
+    bls_dkg_id, Amount, AmountSecrets, Dbc, DbcContent, Error, Mint, ReissueRequest,
+    SimpleKeyManager, SimpleSigner, SimpleSpendBook,
 };
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
@@ -20,7 +20,7 @@ fn decrypt_amount_secrets(
 }
 
 fn genesis(
-    amount: u64,
+    amount: Amount,
 ) -> (
     Mint<SimpleKeyManager, SimpleSpendBook>,
     bls_dkg::outcome::Outcome,
@@ -176,7 +176,7 @@ fn bench_reissue_100_to_1(c: &mut Criterion) {
             (dbc, amount_secrets)
         }))
         .add_output(sn_dbc::Output {
-            amount: n_outputs as u64,
+            amount: n_outputs as Amount,
             owner: bls_dkg_id().public_key_set.public_key(),
         })
         .build()

--- a/examples/mint-repl/mint-repl.rs
+++ b/examples/mint-repl/mint-repl.rs
@@ -20,7 +20,7 @@ use rustyline::error::ReadlineError;
 use rustyline::Editor;
 use serde::{Deserialize, Serialize};
 use sn_dbc::{
-    Dbc, DbcContent, DbcTransaction, Hash, Mint, MintSignatures, NodeSignature, Output,
+    Amount, Dbc, DbcContent, DbcTransaction, Hash, Mint, MintSignatures, NodeSignature, Output,
     ReissueRequest, ReissueTransaction, SimpleKeyManager as KeyManager, SimpleSigner as Signer,
     SimpleSpendBook as SpendBook, TransactionBuilder,
 };
@@ -160,7 +160,7 @@ fn newmint() -> Result<MintInfo> {
     }
 
     let amount = loop {
-        let amount: u64 = readline_prompt("\nTotal Money Supply Amount: ")?.parse()?;
+        let amount: Amount = readline_prompt("\nTotal Money Supply Amount: ")?.parse()?;
 
         if amount == 0 {
             let answer = readline_prompt(
@@ -203,13 +203,13 @@ fn newmint() -> Result<MintInfo> {
 }
 
 /// creates a new mint using a random seed.
-fn mk_new_random_mint(threshold: usize, amount: u64) -> Result<MintInfo> {
+fn mk_new_random_mint(threshold: usize, amount: Amount) -> Result<MintInfo> {
     let (poly, secret_key_set) = mk_secret_key_set(threshold)?;
     mk_new_mint(secret_key_set, poly, amount)
 }
 
 /// creates a new mint from an existing SecretKeySet that was seeded by poly.
-fn mk_new_mint(secret_key_set: SecretKeySet, poly: Poly, amount: u64) -> Result<MintInfo> {
+fn mk_new_mint(secret_key_set: SecretKeySet, poly: Poly, amount: Amount) -> Result<MintInfo> {
     let genesis_pubkey = secret_key_set.public_keys().public_key();
     let mut mints: Vec<Mint<KeyManager, SpendBook>> = Default::default();
 
@@ -652,7 +652,7 @@ fn prepare_tx() -> Result<()> {
             inputs_amount_sum, remaining
         );
         let line = readline_prompt("Amount, or 'cancel': ")?;
-        let amount: u64 = if line == "cancel" {
+        let amount: Amount = if line == "cancel" {
             println!("\nprepare_tx cancelled\n");
             break;
         } else {
@@ -945,7 +945,7 @@ fn reissue_ez(mintinfo: &mut MintInfo) -> Result<()> {
             inputs_amount_sum, remaining
         );
         let line = readline_prompt("Amount, or 'cancel': ")?;
-        let amount: u64 = if line == "cancel" {
+        let amount: Amount = if line == "cancel" {
             println!("\nreissue_ez cancelled\n");
             return Ok(());
         } else {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -3,11 +3,11 @@ use std::iter::FromIterator;
 
 use curve25519_dalek_ng::scalar::Scalar;
 
-use crate::{AmountSecrets, Dbc, DbcContent, Hash, ReissueTransaction, Result};
+use crate::{Amount, AmountSecrets, Dbc, DbcContent, Hash, ReissueTransaction, Result};
 
 ///! Unblinded data for creating sn_dbc::DbcContent
 pub struct Output {
-    pub amount: u64,
+    pub amount: Amount,
     pub owner: blsttc::PublicKey,
 }
 
@@ -45,11 +45,11 @@ impl TransactionBuilder {
             .collect::<BTreeSet<_>>()
     }
 
-    pub fn inputs_amount_sum(&self) -> u64 {
+    pub fn inputs_amount_sum(&self) -> Amount {
         self.inputs.iter().map(|(_, s)| s.amount).sum()
     }
 
-    pub fn outputs_amount_sum(&self) -> u64 {
+    pub fn outputs_amount_sum(&self) -> Amount {
         self.outputs.iter().map(|o| o.amount).sum()
     }
 

--- a/src/dbc.rs
+++ b/src/dbc.rs
@@ -63,16 +63,16 @@ mod tests {
 
     use crate::tests::{NonZeroTinyInt, TinyInt};
     use crate::{
-        DbcHelper, KeyManager, Mint, ReissueRequest, ReissueTransaction, SimpleKeyManager,
+        Amount, DbcHelper, KeyManager, Mint, ReissueRequest, ReissueTransaction, SimpleKeyManager,
         SimpleSigner, SimpleSpendBook,
     };
 
-    fn divide(amount: u64, n_ways: u8) -> impl Iterator<Item = u64> {
+    fn divide(amount: Amount, n_ways: u8) -> impl Iterator<Item = Amount> {
         (0..n_ways).into_iter().map(move |i| {
-            let equal_parts = amount / (n_ways as u64);
-            let leftover = amount % (n_ways as u64);
+            let equal_parts = amount / (n_ways as Amount);
+            let leftover = amount % (n_ways as Amount);
 
-            let odd_compensation = if (i as u64) < leftover { 1 } else { 0 };
+            let odd_compensation = if (i as Amount) < leftover { 1 } else { 0 };
             equal_parts + odd_compensation
         })
     }
@@ -89,7 +89,7 @@ mod tests {
         let amount_secrets = DbcHelper::decrypt_amount_secrets(dbc_owner, &dbc.content)?;
 
         let mut outputs_bf_sum: Scalar = Default::default();
-        let output_amounts: Vec<u64> = divide(amount_secrets.amount, n_ways).collect();
+        let output_amounts: Vec<Amount> = divide(amount_secrets.amount, n_ways).collect();
         let outputs = HashSet::from_iter(output_amounts.iter().enumerate().map(|(i, amount)| {
             let blinding_factor = DbcContent::calc_blinding_factor(
                 i == output_amounts.len() - 1,
@@ -297,7 +297,7 @@ mod tests {
 
         let fuzzed_content = DbcContent::new(
             fuzzed_parents,
-            amount + extra_output_amount.coerce::<u64>(),
+            amount + extra_output_amount.coerce::<Amount>(),
             crate::bls_dkg_id().public_key_set.public_key(),
             DbcContent::random_blinding_factor(),
         )?;

--- a/src/dbc_content.rs
+++ b/src/dbc_content.rs
@@ -32,6 +32,8 @@ pub struct BlindedOwner(Hash);
 const AMT_SIZE: usize = 8; // Amount size: 8 bytes (u64)
 const BF_SIZE: usize = 32; // Blinding factor size: 32 bytes (Scalar)
 
+pub type Amount = u64;
+
 impl BlindedOwner {
     pub fn new(owner: &PublicKey, parents: &BTreeSet<DbcContentHash>) -> Self {
         let mut sha3 = Sha3::v256();
@@ -52,7 +54,7 @@ impl BlindedOwner {
 /// must be kept secret (encrypted) in the DBC.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub struct AmountSecrets {
-    pub amount: u64,
+    pub amount: Amount,
     pub blinding_factor: Scalar,
 }
 
@@ -67,7 +69,7 @@ impl AmountSecrets {
 
     /// build AmountSecrets from fixed size byte array.
     pub fn from_bytes(bytes: [u8; AMT_SIZE + BF_SIZE]) -> Self {
-        let amount = u64::from_le_bytes({
+        let amount = Amount::from_le_bytes({
             let mut b = [0u8; AMT_SIZE];
             b.copy_from_slice(&bytes[0..AMT_SIZE]);
             b
@@ -88,7 +90,7 @@ impl AmountSecrets {
         if bytes.len() != AMT_SIZE + BF_SIZE {
             return Err(Error::AmountSecretsBytesInvalid);
         }
-        let amount = u64::from_le_bytes({
+        let amount = Amount::from_le_bytes({
             let mut b = [0u8; AMT_SIZE];
             b.copy_from_slice(&bytes[0..AMT_SIZE]);
             b
@@ -119,7 +121,7 @@ impl DbcContent {
     // Create a new DbcContent for signing.
     pub fn new(
         parents: BTreeSet<DbcContentHash>,
-        amount: u64,
+        amount: Amount,
         owner_key: PublicKey,
         blinding_factor: Scalar,
     ) -> Result<Self, Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ mod mint;
 pub use crate::{
     builder::{Output, TransactionBuilder},
     dbc::Dbc,
-    dbc_content::{AmountSecrets, BlindedOwner, DbcContent},
+    dbc_content::{Amount, AmountSecrets, BlindedOwner, DbcContent},
     dbc_transaction::DbcTransaction,
     error::{Error, Result},
     key_manager::{
@@ -126,7 +126,7 @@ impl DbcHelper {
     pub fn decrypt_amount(
         owner: &bls_dkg::outcome::Outcome,
         dbcc: &DbcContent,
-    ) -> Result<u64, Error> {
+    ) -> Result<Amount, Error> {
         Ok(Self::decrypt_amount_secrets(owner, dbcc)?.amount)
     }
 }


### PR DESCRIPTION
It's been bugging me that we use u64 everywhere for amounts.   This alias would make it easier to change in the future if we ever should wish to.  (with the caveat that we are presently limited to u64 by bulletproofs::RangeProof)