### PR TITLE
add ReissueShare and DbcBuilder to simplify aggregating reissue results from mint nodes

### DIFF
--- a/benches/reissue.rs
+++ b/benches/reissue.rs
@@ -153,11 +153,16 @@ fn bench_reissue_100_to_1(c: &mut Criterion) {
         input_ownership_proofs,
     };
 
-    let (transaction, transaction_sigs) = genesis
+    let reissue_share = genesis
         .reissue(reissue.clone(), BTreeSet::from_iter([genesis_dbc.name()]))
         .unwrap();
 
-    let (mint_key_set, mint_sig_share) = transaction_sigs.values().cloned().next().unwrap();
+    let (mint_key_set, mint_sig_share) = reissue_share
+        .mint_node_signatures
+        .values()
+        .cloned()
+        .next()
+        .unwrap();
 
     let mint_sig = genesis_owner
         .public_key_set
@@ -166,7 +171,7 @@ fn bench_reissue_100_to_1(c: &mut Criterion) {
 
     let dbcs = Vec::from_iter(reissue.transaction.outputs.into_iter().map(|content| Dbc {
         content,
-        transaction: transaction.clone(),
+        transaction: reissue_share.dbc_transaction.clone(),
         transaction_sigs: BTreeMap::from_iter([(
             genesis_dbc.name(),
             (mint_key_set.public_key(), mint_sig.clone()),

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -135,12 +135,12 @@ impl DbcBuilder {
     /// has not been set or no ReissueShare has been added.
     pub fn build(self) -> Result<Vec<Dbc>> {
         if self.reissue_shares.is_empty() {
-            return Ok(vec![]);
+            return Err(Error::NoReissueShares);
         }
 
         let reissue_transaction = match self.reissue_transaction {
             Some(rt) => rt,
-            None => return Ok(vec![]),
+            None => return Err(Error::NoReissueTransaction),
         };
 
         let mut mint_sig_shares: Vec<NodeSignature> = Default::default();

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,9 +1,13 @@
+use blsttc::{PublicKeySet, SignatureShare};
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::iter::FromIterator;
 
 use curve25519_dalek_ng::scalar::Scalar;
 
-use crate::{Amount, AmountSecrets, Dbc, DbcContent, Hash, ReissueTransaction, Result};
+use crate::{
+    Amount, AmountSecrets, Dbc, DbcContent, Error, Hash, NodeSignature, ReissueShare,
+    ReissueTransaction, Result,
+};
 
 ///! Unblinded data for creating sn_dbc::DbcContent
 pub struct Output {
@@ -92,5 +96,137 @@ impl TransactionBuilder {
         );
         let outputs = HashSet::from_iter(outputs_and_owners.into_iter().map(|(o, _)| o));
         Ok((ReissueTransaction { inputs, outputs }, output_owners))
+    }
+}
+
+/// A Builder for aggregating ReissueShare (Mint::reissue() results)
+/// from multiple mint nodes and combining signatures to
+/// generate the final Dbc outputs.
+#[derive(Default)]
+pub struct DbcBuilder {
+    pub reissue_transaction: Option<ReissueTransaction>,
+    pub reissue_shares: Vec<ReissueShare>,
+}
+
+impl DbcBuilder {
+    /// Create a new DbcBuilder from a ReissueTransaction
+    pub fn new(reissue_transaction: ReissueTransaction) -> Self {
+        Self {
+            reissue_transaction: Some(reissue_transaction),
+            reissue_shares: Default::default(),
+        }
+    }
+
+    /// Add a ReissueShare from Mint::reissue()
+    pub fn add_reissue_share(mut self, reissue_share: ReissueShare) -> Self {
+        self.reissue_shares.push(reissue_share);
+        self
+    }
+
+    /// Set the ReissueTransaction
+    pub fn set_reissue_transaction(mut self, reissue_transaction: ReissueTransaction) -> Self {
+        self.reissue_transaction = Some(reissue_transaction);
+        self
+    }
+
+    /// Build the output DBCs
+    ///
+    /// Note that the result Vec may be empty if the ReissueTransaction
+    /// has not been set or no ReissueShare has been added.
+    pub fn build(self) -> Result<Vec<Dbc>> {
+        if self.reissue_shares.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let reissue_transaction = match self.reissue_transaction {
+            Some(rt) => rt,
+            None => return Ok(vec![]),
+        };
+
+        let mut mint_sig_shares: Vec<NodeSignature> = Default::default();
+        let mut pk_set: HashSet<PublicKeySet> = Default::default();
+
+        for rs in self.reissue_shares.iter() {
+            // Make a list of NodeSignature (sigshare from each Mint Node)
+            let mut node_shares: Vec<NodeSignature> = rs
+                .mint_node_signatures
+                .iter()
+                .map(|e| e.1 .1.clone())
+                .collect();
+            mint_sig_shares.append(&mut node_shares);
+
+            let pub_key_sets: HashSet<PublicKeySet> = rs
+                .mint_node_signatures
+                .iter()
+                .map(|e| e.1 .0.clone())
+                .collect();
+
+            // add pubkeyset to HashSet, so we can verify there is only one distinct PubKeySet
+            pk_set = &pk_set | &pub_key_sets; // union the sets together.
+
+            // Verify transaction returned to us by the Mint matches our request
+            if reissue_transaction.blinded() != rs.dbc_transaction {
+                return Err(Error::ReissueShareDbcTransactionMismatch);
+            }
+
+            // Verify that mint sig count matches input count.
+            if rs.mint_node_signatures.len() != reissue_transaction.inputs.len() {
+                return Err(Error::ReissueShareMintNodeSignaturesLenMismatch);
+            }
+
+            // Verify that each input has a NodeSignature
+            for input in reissue_transaction.inputs.iter() {
+                if rs.mint_node_signatures.get(&input.name()).is_none() {
+                    return Err(Error::ReissueShareMintNodeSignatureNotFoundForInput);
+                }
+            }
+        }
+
+        // verify that PublicKeySet for all Dbc in all ReissueShare match.
+        if pk_set.len() != 1 {
+            return Err(Error::ReissueSharePublicKeySetMismatch);
+        }
+        let mint_public_key_set = match pk_set.iter().next() {
+            Some(pks) => pks,
+            None => return Err(Error::ReissueSharePublicKeySetMismatch),
+        };
+
+        // Transform Vec<NodeSignature> to Vec<u64, &SignatureShare>
+        let mint_sig_shares_ref: Vec<(u64, &SignatureShare)> = mint_sig_shares
+            .iter()
+            .map(|e| e.threshold_crypto())
+            .collect();
+
+        // Note: we can just use the first item because we already verified that
+        // all the ReissueShare match for dbc_transaction
+        let dbc_transaction = &self.reissue_shares[0].dbc_transaction;
+
+        // Combine signatures from all the mint nodes to obtain Mint's Signature.
+        let mint_sig = mint_public_key_set.combine_signatures(mint_sig_shares_ref)?;
+
+        // Form the final output DBCs, with Mint's Signature for each.
+        let mut output_dbcs: Vec<Dbc> = reissue_transaction
+            .outputs
+            .iter()
+            .map(|content| Dbc {
+                content: content.clone(),
+                transaction: dbc_transaction.clone(),
+                transaction_sigs: reissue_transaction
+                    .inputs
+                    .iter()
+                    .map(|input| {
+                        (
+                            input.name(),
+                            (mint_public_key_set.public_key(), mint_sig.clone()),
+                        )
+                    })
+                    .collect(),
+            })
+            .collect();
+
+        // sort outputs by name
+        output_dbcs.sort_by_key(|d| d.name());
+
+        Ok(output_dbcs)
     }
 }

--- a/src/dbc_content.rs
+++ b/src/dbc_content.rs
@@ -60,7 +60,7 @@ pub struct AmountSecrets {
 
 impl AmountSecrets {
     /// Convert to bytes
-    pub fn to_bytes(&self) -> Vec<u8> {
+    pub fn to_bytes(self) -> Vec<u8> {
         let mut v: Vec<u8> = Default::default();
         v.extend(&self.amount.to_le_bytes());
         v.extend(&self.blinding_factor.to_bytes());

--- a/src/error.rs
+++ b/src/error.rs
@@ -54,6 +54,18 @@ pub enum Error {
     #[error("Dbc Content parents is not the same transaction inputs")]
     DbcContentParentsDifferentFromTransactionInputs,
 
+    #[error("The PublicKeySet differs between ReissueShare entries")]
+    ReissueSharePublicKeySetMismatch,
+
+    #[error("The MintNodeSignature count in ReissueShare differs from input count in ReissueTransaction")]
+    ReissueShareMintNodeSignaturesLenMismatch,
+
+    #[error("MintNodeSignature not found for an input in ReissueTransaction")]
+    ReissueShareMintNodeSignatureNotFoundForInput,
+
+    #[error("The DbcTransaction in ReissueShare differs from that of ReissueTransaction")]
+    ReissueShareDbcTransactionMismatch,
+
     #[error("RangeProof error: {0}")]
     RangeProof(#[from] bulletproofs::ProofError),
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -66,6 +66,12 @@ pub enum Error {
     #[error("The DbcTransaction in ReissueShare differs from that of ReissueTransaction")]
     ReissueShareDbcTransactionMismatch,
 
+    #[error("No reissue shares")]
+    NoReissueShares,
+
+    #[error("No reissue transaction")]
+    NoReissueTransaction,
+
     #[error("RangeProof error: {0}")]
     RangeProof(#[from] bulletproofs::ProofError),
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ mod key_manager;
 mod mint;
 
 pub use crate::{
-    builder::{Output, TransactionBuilder},
+    builder::{DbcBuilder, Output, TransactionBuilder},
     dbc::Dbc,
     dbc_content::{Amount, AmountSecrets, BlindedOwner, DbcContent},
     dbc_transaction::DbcTransaction,
@@ -35,8 +35,8 @@ pub use crate::{
         SimpleSigner,
     },
     mint::{
-        Mint, MintSignatures, ReissueRequest, ReissueTransaction, SimpleSpendBook, SpendBook,
-        GENESIS_DBC_INPUT,
+        Mint, MintNodeSignatures, ReissueRequest, ReissueShare, ReissueTransaction,
+        SimpleSpendBook, SpendBook, GENESIS_DBC_INPUT,
     },
 };
 


### PR DESCRIPTION
Changes:
* Mint::reissue() now returns a ReissueShare instead of a tuple
* adds DbcBuilder to aggregate ReissueShare, validate, combine signatures, and gen output DBCs
* AmountSecrets::to_bytes() takes self instead of &self.  recommended by clippy.
* updates tests, mint-repl, and reissue bench to use DbcBuilder and/or ReissueShare

----
**Discussion for a possible followup PR:**

One observation I made while implementing this is that we return PublicKeySet for every output DBC in every reissue().  Yet to combine signatures one must use a single PublicKeySet.   This means the client should/must verify that all returned PublicKeySet are the same which is a bit convoluted with this structure.  It would be a bit simpler to just return a single PublicKeySet from Mint::reissue() in the ReissueShare and omit it from MintNodeSignatures, which then becomes **BTreeMap<DbcContentHash, NodeSignature>** instead of **BTreeMap<DbcContentHash, (PublicKeySet, NodeSignature)>**.

Is there ever a situation where we would actually want distinct PublicKeySet per output Dbc per MintNode?   If so, DbcBuilder::build() would fail miserably when it encounters that... 