### PR TITLE
feat: add ReissueRequestBuilder to simplify aggregating dbc ownership proofs

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,12 +1,12 @@
-use blsttc::{PublicKeySet, SignatureShare};
-use std::collections::{BTreeSet, HashMap, HashSet};
+use blsttc::{Fr, IntoFr, PublicKey, PublicKeySet, SecretKeyShare, Signature, SignatureShare};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::iter::FromIterator;
 
 use curve25519_dalek_ng::scalar::Scalar;
 
 use crate::{
-    Amount, AmountSecrets, Dbc, DbcContent, Error, Hash, NodeSignature, ReissueShare,
-    ReissueTransaction, Result,
+    Amount, AmountSecrets, Dbc, DbcContent, DbcContentHash, Error, Hash, NodeSignature,
+    ReissueRequest, ReissueShare, ReissueTransaction, Result,
 };
 
 ///! Unblinded data for creating sn_dbc::DbcContent
@@ -96,6 +96,107 @@ impl TransactionBuilder {
         );
         let outputs = HashSet::from_iter(outputs_and_owners.into_iter().map(|(o, _)| o));
         Ok((ReissueTransaction { inputs, outputs }, output_owners))
+    }
+}
+
+/// Builds a ReissueRequest from a ReissueTransaction and
+/// any number of (input) DBC hashes with associated ownership share(s).
+#[derive(Default)]
+pub struct ReissueRequestBuilder {
+    pub reissue_transaction: Option<ReissueTransaction>,
+    #[allow(clippy::type_complexity)]
+    pub signers_by_dbc: HashMap<DbcContentHash, Vec<(PublicKeySet, (Fr, SecretKeyShare))>>,
+}
+
+impl ReissueRequestBuilder {
+    /// Create a new ReissueRequestBuilder from a ReissueTransaction
+    pub fn new(reissue_transaction: ReissueTransaction) -> Self {
+        Self {
+            reissue_transaction: Some(reissue_transaction),
+            signers_by_dbc: Default::default(),
+        }
+    }
+
+    /// Set the ReissueTransaction
+    pub fn set_reissue_transaction(mut self, reissue_transaction: ReissueTransaction) -> Self {
+        self.reissue_transaction = Some(reissue_transaction);
+        self
+    }
+
+    /// Add a single signer share for a DBC hash
+    pub fn add_dbc_signer<FR: IntoFr>(
+        mut self,
+        dbc: DbcContentHash,
+        public_key_set: PublicKeySet,
+        share_index: FR,
+        secret_key_share: SecretKeyShare,
+    ) -> Self {
+        let entry = self.signers_by_dbc.entry(dbc).or_insert_with(Vec::new);
+        (*entry).push((public_key_set, (share_index.into_fr(), secret_key_share)));
+        self
+    }
+
+    /// Add a list of signer shares for a DBC hash
+    pub fn add_dbc_signers<FR: IntoFr>(
+        mut self,
+        dbc: DbcContentHash,
+        public_key_set: PublicKeySet,
+        secret_key_shares: Vec<(FR, SecretKeyShare)>,
+    ) -> Self {
+        let entry = self.signers_by_dbc.entry(dbc).or_insert_with(Vec::new);
+        for (idx, secret_key_share) in secret_key_shares.into_iter() {
+            (*entry).push((public_key_set.clone(), (idx.into_fr(), secret_key_share)));
+        }
+        self
+    }
+
+    /// Aggregates SecretKeyShares for all DBC owners in a ReissueTransaction
+    /// in order to combine signature shares into Signatures, thereby
+    /// creating the ownership proofs necessary to construct
+    /// a ReissueRequest.
+    pub fn build(self) -> Result<ReissueRequest> {
+        let transaction = match self.reissue_transaction {
+            Some(rt) => rt,
+            None => return Err(Error::NoReissueTransaction),
+        };
+
+        let mut input_ownership_proofs: HashMap<DbcContentHash, (PublicKey, Signature)> =
+            Default::default();
+
+        for (dbc, signers) in self.signers_by_dbc.iter() {
+            let pks_set: HashSet<PublicKeySet> = signers.iter().map(|s| s.0.clone()).collect();
+            if pks_set.len() != 1 {
+                return Err(Error::ReissueRequestPublicKeySetMismatch);
+            }
+            let owner_public_key_set = match pks_set.iter().next() {
+                Some(pks) => pks,
+                None => return Err(Error::ReissueRequestPublicKeySetMismatch),
+            };
+
+            let sig_shares: BTreeMap<Fr, SignatureShare> = signers
+                .iter()
+                .map(|s| {
+                    let idx = s.1 .0;
+                    let sks = &s.1 .1;
+                    let sig_share = sks.sign(transaction.blinded().hash());
+                    (idx, sig_share)
+                })
+                .collect();
+
+            let sig_shares_ref: BTreeMap<Fr, &SignatureShare> = sig_shares
+                .iter()
+                .map(|(idx, share)| (*idx, share))
+                .collect();
+
+            let signature = owner_public_key_set.combine_signatures(sig_shares_ref)?;
+            input_ownership_proofs.insert(*dbc, (owner_public_key_set.public_key(), signature));
+        }
+
+        let rr = ReissueRequest {
+            transaction,
+            input_ownership_proofs,
+        };
+        Ok(rr)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -54,6 +54,9 @@ pub enum Error {
     #[error("Dbc Content parents is not the same transaction inputs")]
     DbcContentParentsDifferentFromTransactionInputs,
 
+    #[error("The PublicKeySet differs between ReissueRequest entries")]
+    ReissueRequestPublicKeySetMismatch,
+
     #[error("The PublicKeySet differs between ReissueShare entries")]
     ReissueSharePublicKeySetMismatch,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ mod key_manager;
 mod mint;
 
 pub use crate::{
-    builder::{DbcBuilder, Output, TransactionBuilder},
+    builder::{DbcBuilder, Output, ReissueRequestBuilder, TransactionBuilder},
     dbc::Dbc,
     dbc_content::{Amount, AmountSecrets, BlindedOwner, DbcContent},
     dbc_transaction::DbcTransaction,


### PR DESCRIPTION
So now creating a ReissueRequest can look something like:

```
        let rr = ReissueRequestBuilder::new(reissue_tx);
            .add_dbc_signer(
                genesis_dbc.name(),
                genesis_owner.public_key_set,
                genesis_owner.index,
                genesis_owner.secret_key_share,
            )
            .build()?;
```

or for a more complicated case with multiple input dbcs and 2 signers for each:

```
let owner_shares = vec![(0, share0),(1, share1)];
let mut builder = ReissueRequestBuilder::new(reissue_tx.clone());
for dbc in reissue_tx.inputs.iter() {
    builder.add_dbc_signers(
        dbc.name(),
        owner.public_key_set,
        owner_shares
    );
}
let reissue_request = builder.build()?;
```