### PR TITLE
store mint's root public key in Dbc rather than derived-from-denom key

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -240,7 +240,7 @@ impl DbcBuilder {
         if pk_set.len() != 1 {
             return Err(Error::ReissueSharePublicKeySetMismatch);
         }
-        let mint_root_public_key_set = match pk_set.iter().next() {
+        let mint_public_key_set = match pk_set.iter().next() {
             Some(pks) => pks,
             None => return Err(Error::ReissueSharePublicKeySetMismatch),
         };
@@ -262,15 +262,17 @@ impl DbcBuilder {
             }
 
             // Combine signatures from all the mint nodes to obtain Mint's Signature.
-            let mint_signature = mint_root_public_key_set
-                .derive_child(&dbc_envelope.denomination.to_bytes())
+            // note: logically speaking, it seems we should derive the denomination
+            //       pubkey here (and it works) however that turns out not to be
+            //       necessary, so we skip the extra ::derive_child() call.
+            let mint_denomination_signature = mint_public_key_set
                 .combine_signatures(&mint_sig_shares)?;
 
             // Form the final output DBCs, with Mint's Signature for each.
             let dbc = Dbc {
                 content: output_secret.dbc_content,
-                mint_root_public_key: mint_root_public_key_set.public_key(),
-                mint_signature,
+                mint_public_key: mint_public_key_set.public_key(),
+                mint_denomination_signature,
             };
 
             output_dbcs.push(dbc);

--- a/src/dbc.rs
+++ b/src/dbc.rs
@@ -10,10 +10,15 @@ use crate::{DbcContent, Denomination, Error, KeyManager, PublicKey, Result, Sign
 use serde::{Deserialize, Serialize};
 use tiny_keccak::{Hasher, Sha3};
 
+/// mint_root_public_key is the root pubkey, from which
+/// denomination-specific pubkeys are derived.
+///
+/// mint_signature is a signature that can be verified with:
+/// mint_root_public_key.derive_child(&self.denomination().to_bytes()).verify(self.mint_signature)
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
 pub struct Dbc {
     pub content: DbcContent,
-    pub mint_public_key: PublicKey,
+    pub mint_root_public_key: PublicKey,
     pub mint_signature: Signature,
 }
 
@@ -34,7 +39,7 @@ impl Dbc {
         let mut sha3 = Sha3::v256();
 
         sha3.update(&self.content.hash().0);
-        sha3.update(&self.mint_public_key.to_bytes());
+        sha3.update(&self.mint_root_public_key.to_bytes());
         sha3.update(&self.mint_signature.to_bytes());
 
         let mut hash = [0u8; 32];
@@ -52,7 +57,7 @@ impl Dbc {
             .verify_slip(
                 &self.content.slip(),
                 &self.content.denomination().to_bytes(),
-                &self.mint_public_key,
+                &self.mint_root_public_key,
                 &self.mint_signature,
             )
             .map_err(|e| Error::Signing(e.to_string()))

--- a/src/dbc.rs
+++ b/src/dbc.rs
@@ -10,16 +10,17 @@ use crate::{DbcContent, Denomination, Error, KeyManager, PublicKey, Result, Sign
 use serde::{Deserialize, Serialize};
 use tiny_keccak::{Hasher, Sha3};
 
-/// mint_root_public_key is the root pubkey, from which
+/// mint_public_key is the root pubkey, from which
 /// denomination-specific pubkeys are derived.
 ///
-/// mint_signature is a signature that can be verified with:
-/// mint_root_public_key.derive_child(&self.denomination().to_bytes()).verify(self.mint_signature)
+/// mint_denomination_signature is a signature that can be verified with:
+/// mint_public_key.derive_child(&self.denomination().to_bytes())
+///     .verify(self.mint_denomination_signature)
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
 pub struct Dbc {
     pub content: DbcContent,
-    pub mint_root_public_key: PublicKey,
-    pub mint_signature: Signature,
+    pub mint_public_key: PublicKey,
+    pub mint_denomination_signature: Signature,
 }
 
 impl Dbc {
@@ -39,8 +40,8 @@ impl Dbc {
         let mut sha3 = Sha3::v256();
 
         sha3.update(&self.content.hash().0);
-        sha3.update(&self.mint_root_public_key.to_bytes());
-        sha3.update(&self.mint_signature.to_bytes());
+        sha3.update(&self.mint_public_key.to_bytes());
+        sha3.update(&self.mint_denomination_signature.to_bytes());
 
         let mut hash = [0u8; 32];
         sha3.finalize(&mut hash);
@@ -57,8 +58,8 @@ impl Dbc {
             .verify_slip(
                 &self.content.slip(),
                 &self.content.denomination().to_bytes(),
-                &self.mint_root_public_key,
-                &self.mint_signature,
+                &self.mint_public_key,
+                &self.mint_denomination_signature,
             )
             .map_err(|e| Error::Signing(e.to_string()))
     }

--- a/src/key_manager.rs
+++ b/src/key_manager.rs
@@ -200,10 +200,6 @@ impl Keys {
     }
 
     fn verify_known_key(&self, key: &PublicKey) -> Result<()> {
-        // note: if we are caching many keys (eg after many section churns), this could get slow.
-        // It would be faster to store/lookup denomination keys for each master key.
-        // Alternatively, if we included the mint's derivation root in the DBC, then we
-        // could just "know" it.  Though that increases DBC size and wire usage.
 
         for pk in self.0.iter() {
             if pk == key {

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -272,22 +272,21 @@ mod tests {
 
         let ses = &genesis.signed_envelope_share;
 
-        let mint_signature = genesis
+        // note: logically speaking, it seems we should derive the denomination
+        //       pubkey here (and it works) however that turns out not to be
+        //       necessary, so we skip the extra ::derive_child() call.
+        let mint_denomination_signature = genesis
             .public_key_set
-            .derive_child(&genesis_denomination().to_bytes())
             .combine_signatures(vec![(
                 ses.signature_share_index(),
                 &ses.signature_share_for_slip(genesis.slip_preparer.blinding_factor())?,
             )])
             .unwrap();
 
-        // let denom_idx = genesis.dbc_content.denomination().to_bytes();
-        // let mint_derived_pks = genesis.public_key_set.derive_child(&denom_idx);
-
         let genesis_dbc = Dbc {
             content: genesis.dbc_content,
-            mint_root_public_key: genesis.public_key_set.public_key(),
-            mint_signature,
+            mint_public_key: genesis.public_key_set.public_key(),
+            mint_denomination_signature,
         };
 
         Ok((genesis_dbc, genesis_node, genesis_owner))

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -251,6 +251,7 @@ mod tests {
         Denomination::One(8)
     }
 
+    #[allow(clippy::type_complexity)]    // for now
     fn genesis() -> Result<(
         Dbc,
         MintNode<SimpleKeyManager, Arc<Mutex<SimpleSpendBook>>>,
@@ -273,18 +274,19 @@ mod tests {
 
         let mint_signature = genesis
             .public_key_set
+            .derive_child(&genesis_denomination().to_bytes())
             .combine_signatures(vec![(
                 ses.signature_share_index(),
                 &ses.signature_share_for_slip(genesis.slip_preparer.blinding_factor())?,
             )])
             .unwrap();
 
-        let denom_idx = genesis.dbc_content.denomination().to_bytes();
-        let mint_derived_pks = genesis.public_key_set.derive_child(&denom_idx);
+        // let denom_idx = genesis.dbc_content.denomination().to_bytes();
+        // let mint_derived_pks = genesis.public_key_set.derive_child(&denom_idx);
 
         let genesis_dbc = Dbc {
             content: genesis.dbc_content,
-            mint_public_key: mint_derived_pks.public_key(),
+            mint_root_public_key: genesis.public_key_set.public_key(),
             mint_signature,
         };
 


### PR DESCRIPTION
Previously, Dbc::mint_public_key contained a pk derived from the Mint's root public key using Dbc::denomination().to_bytes() as the derivation index.

This had the nice property that one could simply perform:  `self.mint_public_key.verify(self.signature)`

However, given only the derived key, one cannot determine the Mint's public key, which can be useful for validating the mint's authority.

It would be possible to simply add the root pk in addition to the derived key, however that seems wasteful because it enlarges the DBC and the derived key can be calculated.

So the approach taken here is to store the root key and derive the denomination key when signing or validating.  Because the pk and signature stored in the Dbc are no longer "paired", I renamed mint_public_key to mint_root_public_key to hopefully show this distinction and also added a comment about it.

**Performance Impact:**

This change require that the Mint node perform an extra ::derive_child() operation for each input dbc when validating.  Also clients have to derive when building, but I don't think we would care about that.

If we later wish to optimize for speed instead of size, then we could consider storing both PKs in the Dbc instead.

**Unresolved**

One thing I don't understand yet, and would like more eyes on @davidrusu @iancoleman before merging is that when the client is combining mint SignatureShares, it does not appear to matter if we use the root PublicKeySet or derived PublicKeySet.

For example, we can comment out builder.rs line 266 and/or mint.rs line 277, and the resulting DBCs still validate, all tests pass.  Does that seem correct?