### PR TITLE
add autobenches = false to disable building/checking stale benches code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ keywords = [ "Safe", "Network", "SafeNetwork", "SafeUrl", "XorUrl" ]
 authors = [ "MaidSafe Developers <dev@maidsafe.net>" ]
 edition = "2018"
 
+# disable benchmarks temporarily, due to build errors.
+autobenches = false
+
 [features]
 dkg = [ "bls_dkg" ]
 
@@ -55,10 +58,10 @@ rustyline = "8.0.0"
 [target."cfg(unix)".dev-dependencies]
 termios = "0.3.3"
 
-[[bench]]
-name = "reissue"
-harness = false
-required-features = [ "dkg" ]
+# [[bench]]
+# name = "reissue"
+# harness = false
+# required-features = [ "dkg" ]
 
 # [[example]]
 # name = "mint-repl"


### PR DESCRIPTION
clippy has been sad.   this is a pr to make clippy happy again.

specifically it removes benches from any cargo activity using --all-targets.