### PR TITLE
Amount secret pr

### DIFF
--- a/benches/reissue.rs
+++ b/benches/reissue.rs
@@ -5,7 +5,7 @@ use std::convert::TryFrom;
 use std::iter::FromIterator;
 
 use sn_dbc::{
-    bls_dkg_id, Amount, AmountSecrets, Dbc, DbcContent, Error, KeyManager, MintNode,
+    bls_dkg_id, Amount, AmountSecrets, ByteHash, Dbc, DbcContent, Error, KeyManager, MintNode,
     ReissueRequestBuilder, SimpleKeyManager, SimpleSigner, SpentProof, SpentProofShare,
 };
 

--- a/benches/reissue.rs
+++ b/benches/reissue.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::from_iter_instead_of_collect)]
 
 use std::collections::BTreeMap;
+use std::convert::TryFrom;
 use std::iter::FromIterator;
 
 use sn_dbc::{
@@ -15,8 +16,7 @@ fn decrypt_amount_secrets(
     dbcc: &DbcContent,
 ) -> Result<AmountSecrets, Error> {
     let shares = BTreeMap::from_iter([(0, owner.secret_key_share.clone())]);
-
-    dbcc.amount_secrets_by_secret_key_shares(&owner.public_key_set, &shares)
+    AmountSecrets::try_from((&owner.public_key_set, &shares, &dbcc.amount_secrets_cipher))
 }
 
 fn genesis(amount: Amount) -> (MintNode<SimpleKeyManager>, bls_dkg::outcome::Outcome, Dbc) {

--- a/examples/mint-repl/mint-repl.rs
+++ b/examples/mint-repl/mint-repl.rs
@@ -19,8 +19,8 @@ use rustyline::error::ReadlineError;
 use rustyline::Editor;
 use serde::{Deserialize, Serialize};
 use sn_dbc::{
-    Amount, AmountSecrets, Dbc, DbcBuilder, GenesisDbcShare, MintNode, Output, ReissueRequest,
-    ReissueRequestBuilder, ReissueTransaction, SimpleKeyManager as KeyManager,
+    Amount, AmountSecrets, ByteHash, Dbc, DbcBuilder, GenesisDbcShare, MintNode, Output,
+    ReissueRequest, ReissueRequestBuilder, ReissueTransaction, SimpleKeyManager as KeyManager,
     SimpleSigner as Signer, SpendKey, TransactionBuilder,
 };
 use std::collections::{BTreeMap, HashMap};

--- a/examples/mint-repl/spentbook.rs
+++ b/examples/mint-repl/spentbook.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use anyhow::{anyhow, Result};
 use sn_dbc::{
-    KeyManager, ReissueTransaction, Signature, SimpleKeyManager, SpendKey, SpentProof,
+    ByteHash, KeyManager, ReissueTransaction, Signature, SimpleKeyManager, SpendKey, SpentProof,
     SpentProofShare,
 };
 

--- a/src/byte_hash.rs
+++ b/src/byte_hash.rs
@@ -1,0 +1,26 @@
+// Copyright 2021 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use crate::Hash;
+use tiny_keccak::{Hasher, Sha3};
+
+pub trait ByteHash {
+    /// represent as bytes
+    fn to_bytes(&self) -> Vec<u8>;
+
+    /// hash
+    fn hash(&self) -> Hash {
+        let mut sha3 = Sha3::v256();
+
+        sha3.update(&self.to_bytes());
+
+        let mut hash = [0u8; 32];
+        sha3.finalize(&mut hash);
+        Hash::from(hash)
+    }
+}

--- a/src/dbc.rs
+++ b/src/dbc.rs
@@ -33,18 +33,26 @@ impl Dbc {
         self.content.owner
     }
 
+    /// represent as bytes
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut v: Vec<u8> = Default::default();
+
+        v.extend(&self.content.to_bytes());
+        v.extend(&self.transaction.to_bytes());
+
+        for (spendkey, (pk, sig)) in self.transaction_sigs.iter() {
+            v.extend(&spendkey.0.to_bytes());
+            v.extend(&pk.to_bytes());
+            v.extend(&sig.to_bytes());
+        }
+        v
+    }
+
     /// Calculate the spend key index, this index is used to derive the spend key.
     pub fn spend_key_index(&self) -> [u8; 32] {
         let mut sha3 = Sha3::v256();
 
-        sha3.update(&self.content.hash().0);
-        sha3.update(&self.transaction.hash().0);
-
-        for (in_key, (mint_key, mint_sig)) in self.transaction_sigs.iter() {
-            sha3.update(&in_key.0.to_bytes());
-            sha3.update(&mint_key.to_bytes());
-            sha3.update(&mint_sig.to_bytes());
-        }
+        sha3.update(&self.to_bytes());
 
         let mut hash = [0u8; 32];
         sha3.finalize(&mut hash);

--- a/src/dbc.rs
+++ b/src/dbc.rs
@@ -88,7 +88,7 @@ mod tests {
 
     use crate::tests::{NonZeroTinyInt, TinyInt};
     use crate::{
-        Amount, DbcBuilder, DbcHelper, Hash, KeyManager, MintNode, ReissueRequest,
+        Amount, AmountSecrets, DbcBuilder, DbcHelper, Hash, KeyManager, MintNode, ReissueRequest,
         ReissueRequestBuilder, SimpleKeyManager, SimpleSigner, SpentProof, SpentProofShare,
     };
 
@@ -155,7 +155,7 @@ mod tests {
             BTreeSet::new(),
             100,
             crate::bls_dkg_id().public_key_set.public_key(),
-            DbcContent::random_blinding_factor(),
+            AmountSecrets::random_blinding_factor(),
         )?;
 
         let input_owners = BTreeSet::from_iter([input_content.owner]);
@@ -306,7 +306,7 @@ mod tests {
             fuzzed_parents,
             amount + extra_output_amount.coerce::<Amount>(),
             crate::bls_dkg_id().public_key_set.public_key(),
-            DbcContent::random_blinding_factor(),
+            AmountSecrets::random_blinding_factor(),
         )?;
 
         let mut fuzzed_transaction_sigs: BTreeMap<SpendKey, (PublicKey, Signature)> =

--- a/src/dbc_content.rs
+++ b/src/dbc_content.rs
@@ -226,23 +226,30 @@ impl DbcContent {
         })
     }
 
+    /// represent as bytes
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut v: Vec<u8> = Default::default();
+
+        for parent in self.parents.iter() {
+            v.extend(&parent.0.to_bytes());
+        }
+
+        v.extend(&self.amount_secrets_cipher.to_bytes());
+        v.extend(&self.commitment.to_bytes());
+        v.extend(&self.range_proof_bytes);
+        v.extend(&self.owner.to_bytes());
+        v
+    }
+
+    /// generate hash
     pub fn hash(&self) -> Hash {
         let mut sha3 = Sha3::v256();
 
-        // note: fields are hashed in struct order.
-
-        for parent in self.parents.iter() {
-            sha3.update(&parent.0.to_bytes());
-        }
-
-        sha3.update(&self.amount_secrets_cipher.to_bytes());
-        sha3.update(&self.commitment.to_bytes());
-        sha3.update(&self.range_proof_bytes);
-        sha3.update(&self.owner.to_bytes());
+        sha3.update(&self.to_bytes());
 
         let mut hash = [0; 32];
         sha3.finalize(&mut hash);
-        Hash(hash)
+        Hash::from(hash)
     }
 
     /// Verifies range proof, ie that the committed amount is a non-negative u64.

--- a/src/dbc_content.rs
+++ b/src/dbc_content.rs
@@ -68,14 +68,6 @@ impl AmountSecrets {
         }
     }
 
-    pub fn to_pedersen_commitment(&self) -> RistrettoPoint {
-        PedersenGens::default().commit(Scalar::from(self.amount), self.blinding_factor)
-    }
-
-    pub fn to_pedersen_commitment_compressed(&self) -> CompressedRistretto {
-        self.to_pedersen_commitment().compress()
-    }
-
     /// build AmountSecrets from byte array reference
     pub fn from_bytes_ref(bytes: &[u8]) -> Result<Self, Error> {
         if bytes.len() != AMT_SIZE + BF_SIZE {
@@ -97,10 +89,17 @@ impl AmountSecrets {
         })
     }
 
+    /// generate a pedersen commitment
+    pub fn to_pedersen_commitment(&self) -> RistrettoPoint {
+        PedersenGens::default().commit(Scalar::from(self.amount), self.blinding_factor)
+    }
+
+    /// encrypt secrets to public_key producing Ciphertext
     pub fn encrypt(&self, public_key: &PublicKey) -> Ciphertext {
         public_key.encrypt(self.to_bytes().as_slice())
     }
 
+    /// generate a random blinding factor
     pub fn random_blinding_factor() -> Scalar {
         let mut csprng: OsRng = OsRng::default();
         Scalar::random(&mut csprng)
@@ -108,6 +107,7 @@ impl AmountSecrets {
 }
 
 impl From<Amount> for AmountSecrets {
+    /// create AmountSecrets from an amount and a randomly generated blinding factor
     fn from(amount: Amount) -> Self {
         Self {
             amount,

--- a/src/dbc_packet.rs
+++ b/src/dbc_packet.rs
@@ -28,14 +28,23 @@ pub struct DerivedKeySet {
 }
 
 impl DerivedKeySet {
-    pub fn hash(&self) -> Hash {
-        let mut sha3 = Sha3::v256();
-        sha3.update(&self.public_key.to_bytes());
-        sha3.update(&self.derivation_index);
+    /// represent as bytes
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut v: Vec<u8> = Default::default();
+
+        v.extend(&self.public_key.to_bytes());
+        v.extend(&self.derivation_index);
 
         if let Some(sks) = &self.secret_key_set {
-            sha3.update(&sks.to_bytes());
+            v.extend(&sks.to_bytes());
         }
+        v
+    }
+
+    pub fn hash(&self) -> Hash {
+        let mut sha3 = Sha3::v256();
+        sha3.update(&self.to_bytes());
+
         let mut hash = [0u8; 32];
         sha3.finalize(&mut hash);
         Hash(hash)
@@ -116,6 +125,16 @@ pub struct DbcPacket {
 }
 
 impl DbcPacket {
+    /// represent as bytes
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut v: Vec<u8> = Default::default();
+
+        v.extend(&self.dbc.to_bytes());
+        v.extend(&self.owner_keyset.to_bytes());
+
+        v
+    }
+
     pub fn hash(&self) -> Hash {
         let mut sha3 = Sha3::v256();
         sha3.update(&self.dbc.spend_key_index());

--- a/src/dbc_transaction.rs
+++ b/src/dbc_transaction.rs
@@ -25,19 +25,27 @@ impl DbcTransaction {
         Self { inputs, outputs }
     }
 
+    /// represent as bytes
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut v: Vec<u8> = Default::default();
+        for sk in self.inputs.iter() {
+            v.extend(&sk.0.to_bytes());
+        }
+        for o in self.outputs.iter() {
+            v.extend(&o.to_bytes());
+        }
+        v
+    }
+
+    /// generate hash of DbcTransaction
     pub fn hash(&self) -> Hash {
         let mut sha3 = Sha3::v256();
-        for input in self.inputs.iter() {
-            sha3.update(&input.0.to_bytes());
-        }
 
-        for output in self.outputs.iter() {
-            sha3.update(&output.to_bytes());
-        }
+        sha3.update(&self.to_bytes());
 
         let mut hash = [0; 32];
         sha3.finalize(&mut hash);
-        Hash(hash)
+        Hash::from(hash)
     }
 }
 

--- a/src/dbc_transaction.rs
+++ b/src/dbc_transaction.rs
@@ -6,10 +6,9 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::{Hash, PublicKey, SpendKey};
+use crate::{ByteHash, PublicKey, SpendKey};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
-use tiny_keccak::{Hasher, Sha3};
 
 /// The spent identifier of the outputs created from this input
 /// Note these are hashes and not identifiers as the Dbc is not addressable on the network.
@@ -24,9 +23,11 @@ impl DbcTransaction {
     pub fn new(inputs: BTreeSet<SpendKey>, outputs: BTreeSet<PublicKey>) -> Self {
         Self { inputs, outputs }
     }
+}
 
+impl ByteHash for DbcTransaction {
     /// represent as bytes
-    pub fn to_bytes(&self) -> Vec<u8> {
+    fn to_bytes(&self) -> Vec<u8> {
         let mut v: Vec<u8> = Default::default();
         for sk in self.inputs.iter() {
             v.extend(&sk.0.to_bytes());
@@ -35,17 +36,6 @@ impl DbcTransaction {
             v.extend(&o.to_bytes());
         }
         v
-    }
-
-    /// generate hash of DbcTransaction
-    pub fn hash(&self) -> Hash {
-        let mut sha3 = Sha3::v256();
-
-        sha3.update(&self.to_bytes());
-
-        let mut hash = [0; 32];
-        sha3.finalize(&mut hash);
-        Hash::from(hash)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 
 mod builder;
+mod byte_hash;
 mod dbc;
 mod dbc_content;
 mod dbc_packet;
@@ -22,6 +23,7 @@ mod spent_proof;
 
 pub use crate::{
     builder::{DbcBuilder, Output, ReissueRequestBuilder, TransactionBuilder},
+    byte_hash::ByteHash,
     dbc::Dbc,
     dbc_content::{Amount, AmountSecrets, DbcContent},
     dbc_packet::{DbcPacket, DerivedKeySet},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,9 @@ impl AsRef<[u8]> for Hash {
 }
 
 #[cfg(feature = "dkg")]
+use std::convert::TryFrom;
+
+#[cfg(feature = "dkg")]
 pub fn bls_dkg_id() -> bls_dkg::outcome::Outcome {
     use std::collections::BTreeSet;
     use std::iter::FromIterator;
@@ -98,7 +101,7 @@ impl DbcHelper {
             Default::default();
         shares.insert(owner.index, owner.secret_key_share.clone());
 
-        dbcc.amount_secrets_by_secret_key_shares(&owner.public_key_set, &shares)
+        AmountSecrets::try_from((&owner.public_key_set, &shares, &dbcc.amount_secrets_cipher))
     }
 
     pub fn decrypt_amount(

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -14,8 +14,8 @@
 // Outputs <= input value
 
 use crate::{
-    Amount, Dbc, DbcContent, DbcTransaction, Error, KeyManager, NodeSignature, PublicKey,
-    PublicKeySet, Result, SpendKey, SpentProof,
+    Amount, AmountSecrets, Dbc, DbcContent, DbcTransaction, Error, KeyManager, NodeSignature,
+    PublicKey, PublicKeySet, Result, SpendKey, SpentProof,
 };
 use curve25519_dalek_ng::ristretto::RistrettoPoint;
 use serde::{Deserialize, Serialize};
@@ -162,7 +162,7 @@ impl<K: KeyManager> MintNode<K> {
                 .public_key_set()
                 .map_err(|e| Error::Signing(e.to_string()))?
                 .public_key(),
-            DbcContent::random_blinding_factor(),
+            AmountSecrets::random_blinding_factor(),
         )?;
         let transaction = DbcTransaction {
             inputs: BTreeSet::from_iter([genesis_dbc_input()]),
@@ -690,7 +690,7 @@ mod tests {
             Default::default(),
             100,
             input_owner.public_key_set.public_key(),
-            DbcContent::random_blinding_factor(),
+            AmountSecrets::random_blinding_factor(),
         )?;
         let input_owners = BTreeSet::from_iter([input_content.owner]);
 
@@ -712,7 +712,7 @@ mod tests {
                     in_dbc_spend_keys,
                     100,
                     crate::bls_dkg_id().public_key_set.public_key(),
-                    DbcContent::random_blinding_factor(),
+                    AmountSecrets::random_blinding_factor(),
                 )?]),
             },
             spent_proofs: Default::default(),

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -14,8 +14,8 @@
 // Outputs <= input value
 
 use crate::{
-    Amount, AmountSecrets, Dbc, DbcContent, DbcTransaction, Error, KeyManager, NodeSignature,
-    PublicKey, PublicKeySet, Result, SpendKey, SpentProof,
+    Amount, AmountSecrets, ByteHash, Dbc, DbcContent, DbcTransaction, Error, KeyManager,
+    NodeSignature, PublicKey, PublicKeySet, Result, SpendKey, SpentProof,
 };
 use curve25519_dalek_ng::ristretto::RistrettoPoint;
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
Changes to support sn_payment crate:

1. fix: adds commitment and range_proof fields to DbcContent hash().
2. Add hash fn to DerivedKeySet, DbcPacket.
3. move encrypt, decrypt, gen pedersen commitments into AmountSecret

I think it makes the API a bit cleaner and more "rusty" overall.