### PR TITLE
fix: change BTreeSet<SpentProofShare> to HashSet

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -222,7 +222,7 @@ impl TransactionBuilder {
 #[derive(Debug)]
 pub struct ReissueRequestBuilder {
     pub transaction: RingCtTransaction,
-    pub spent_proof_shares: BTreeMap<KeyImage, BTreeSet<SpentProofShare>>,
+    pub spent_proof_shares: BTreeMap<KeyImage, HashSet<SpentProofShare>>,
 }
 
 impl ReissueRequestBuilder {
@@ -241,7 +241,6 @@ impl ReissueRequestBuilder {
             .entry(share.key_image().clone())
             .or_default();
         shares.insert(share);
-
         self
     }
 

--- a/src/key_manager.rs
+++ b/src/key_manager.rs
@@ -29,6 +29,12 @@ impl NodeSignature {
     pub fn threshold_crypto(&self) -> (u64, &SignatureShare) {
         (self.index, &self.sig)
     }
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut bytes = self.index.to_le_bytes().to_vec();
+        bytes.extend(&self.sig.to_bytes());
+        bytes
+    }
 }
 
 pub trait KeyManager {


### PR DESCRIPTION
bug: The ReissueRequestBuilder was only storing 1 SpentProofShare per
KeyImage because the SpentProofShare were being ordered by KeyImage
which is the same for all items in the set for a given input.

The fix is to use a HashSet instead.

changes:

* use HashSet<SpentProofShare> instead of BTreeSet in ReissueRequestBuilder
* add NodeSignature::to_bytes()
* impl (PartialEq, Eq) manually on SpentProofShare
* remove Ord, PartialOrd impls on SpentProofShare
* impl Hash on SpentProofShare
* add SpentProofShare::to_bytes()