### PR TITLE
fix: return Spentbook errors. don't panic

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -96,6 +96,14 @@ pub enum Error {
     #[error("Secret key does not match public key")]
     SecretKeyDoesNotMatchPublicKey,
 
+    // temporary.  should be part of (future) spentbook module.
+    #[error("Key image has already been spent")]
+    SpentbookKeyImageAlreadySpent,
+
+    // temporary.  should be part of (future) spentbook module.
+    #[error("The transaction input has {0:?} public keys but found {1:?} matching outputs in spentbook.")]
+    SpentbookRingSizeMismatch(usize, usize),
+
     #[cfg_attr(feature = "serde", serde(skip))]
     #[error("Bls error: {0}")]
     Blsttc(#[from] blsttc::error::Error),


### PR DESCRIPTION
Adds Error variants for a couple of spentbook errors.

It's a bit gross to put them sn_dbc::Error, however I'm thinking it will be split up soon when we move to a modules approach for MintNode, Wallet, Spentbook.  So this is temporary.

* fix: return Error::SpentbookKeyImageAlreadySpent instead of panic
* fix: return Error::SpentbookRingSizeMismatch instead of assert failure
* add Error::SpentbookKeyImageAlreadySpent
* add Error::SpentbookRingSizeMismatch