### PR TITLE
refactor: improve builder api

### DIFF
--- a/examples/mint-repl/mint-repl.rs
+++ b/examples/mint-repl/mint-repl.rs
@@ -692,10 +692,10 @@ fn prepare_tx(mintinfo: &MintInfo) -> Result<RingCtTransactionRevealed> {
 
     println!("\n\nPreparing RingCtTransaction...\n\n");
 
-    let (reissue_tx, dbc_builder, ringct_material) = tx_builder.build(&mut rng8)?;
+    let (rr_builder, dbc_builder, ringct_material) = tx_builder.build(&mut rng8)?;
 
     Ok(RingCtTransactionRevealed {
-        inner: reissue_tx.transaction,
+        inner: rr_builder.transaction,
         revealed_commitments: dbc_builder.revealed_commitments,
         ringct_material,
         output_owner_map: dbc_builder.output_owner_map,

--- a/src/blst.rs
+++ b/src/blst.rs
@@ -50,7 +50,7 @@ pub type KeyImage = PublicKeyBlstMappable;
 // This is a NewType wrapper for blstrs::G1Affine because in places we
 // need to use it as a key in a BTreeMap.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct PublicKeyBlstMappable(G1Affine);
 
 impl PublicKeyBlstMappable {

--- a/src/spent_proof.rs
+++ b/src/spent_proof.rs
@@ -189,7 +189,7 @@ impl SpentProof {
                 &self.spentbook_pub_key,
                 &self.spentbook_sig,
             )
-            .map_err(|_| Error::InvalidSpentProofSignature(self.key_image().clone()))?;
+            .map_err(|_| Error::InvalidSpentProofSignature(*self.key_image()))?;
         Ok(())
     }
 }

--- a/src/spentbook.rs
+++ b/src/spentbook.rs
@@ -123,7 +123,7 @@ impl SpentBookNodeMock {
         // public_commitments are not available in spentbook for genesis transaction.
         let public_commitments_info: Vec<(KeyImage, Vec<Commitment>)> =
             if key_image == *genesis_key_image {
-                vec![(key_image.clone(), vec![*genesis_public_commitment])]
+                vec![(key_image, vec![*genesis_public_commitment])]
             } else {
                 tx.mlsags
                     .iter()
@@ -180,10 +180,7 @@ impl SpentBookNodeMock {
         }
 
         // Add key_image:tx_hash to key_image index.
-        let existing_tx_hash = self
-            .key_images
-            .entry(key_image.clone())
-            .or_insert_with(|| tx_hash);
+        let existing_tx_hash = self.key_images.entry(key_image).or_insert_with(|| tx_hash);
 
         if *existing_tx_hash == tx_hash {
             // Add tx_hash:tx to transaction entries. (primary data store)


### PR DESCRIPTION
This change makes code a bit cleaner/simpler and more regular for callers of builder APIs. (removes approx 50 lines)  Also hides mlsag key_image, so caller only needs to deal with sn_dbc::KeyImage, which now derives Copy.

* derive Copy on PublicKeyBlstMappable (KeyImage)
* rename TransactionBuilder::material to ringct_material
* rename TransactionBuilder::output_owners to output_owner_map
* return ReissueRequestBuilder and DbcBuilder from TransactionBuilder::build()
* remove key_image.clone() calls
* add ReissueRequestBuilder::inputs() fn to facilitate SpentBook::log_spent()
* update tests, examples, benches to use new builder api