### PR TITLE
feat: verify (always) Amount matches Commitment

### DIFF
--- a/examples/mint-repl/mint-repl.rs
+++ b/examples/mint-repl/mint-repl.rs
@@ -121,14 +121,14 @@ fn main() -> Result<()> {
                     // "reissue_prepared" => reissue_prepared_cli(&mut mintinfo),
                     "reissue" => reissue_cli(&mut mintinfo),
                     "reissue_auto" => reissue_auto_cli(&mut mintinfo),
-                    "validate" => validate(&mintinfo),
+                    "verify" => verify(&mintinfo),
                     "newkey" => newkey(),
                     "newkeys" => newkeys(),
                     "decode" => decode_input(),
                     "quit" | "exit" => break,
                     "help" => {
                         println!(
-                            "\nCommands:\n  Mint:    [mintinfo, newmint]\n  Client:  [newkey, newkeys, reissue, reissue_auto, decode, validate]\n  General: [exit, help]\n"
+                            "\nCommands:\n  Mint:    [mintinfo, newmint]\n  Client:  [newkey, newkeys, reissue, reissue_auto, decode, verify]\n  General: [exit, help]\n"
                         );
                         Ok(())
                     }
@@ -541,12 +541,12 @@ __)(_| |(/_ | \|(/_|_\/\/(_)| |<
     );
 }
 
-/// Implements validate command.  Validates signatures and that a
+/// Implements verify command.  Validates signatures and that a
 /// DBC has not been double-spent.  Also checks if spent/unspent.
-fn validate(mintinfo: &MintInfo) -> Result<()> {
+fn verify(mintinfo: &MintInfo) -> Result<()> {
     let dbc_input = readline_prompt_nl("\nInput DBC, or '[c]ancel': ")?;
     let dbc: Dbc = if dbc_input == "c" {
-        println!("\nvalidate cancelled\n");
+        println!("\nVerify cancelled\n");
         return Ok(());
     } else {
         from_be_hex(&dbc_input)?
@@ -557,7 +557,7 @@ fn validate(mintinfo: &MintInfo) -> Result<()> {
         Owner::PublicKey(_pk) => {
             let sk_input = readline_prompt_nl("\nSecret Key, or '[c]ancel': ")?;
             let sk: SecretKey = if dbc_input == "c" {
-                println!("\nvalidate cancelled\n");
+                println!("\nVerify cancelled\n");
                 return Ok(());
             } else {
                 from_be_hex(&sk_input)?
@@ -566,7 +566,7 @@ fn validate(mintinfo: &MintInfo) -> Result<()> {
         }
     };
 
-    match dbc.confirm_valid(&secret_key, mintinfo.mintnode()?.key_manager()) {
+    match dbc.verify(&secret_key, mintinfo.mintnode()?.key_manager()) {
         Ok(_) => match mintinfo.spentbook()?.is_spent(&dbc.key_image(&secret_key)?) {
             true => println!("\nThis DBC is unspendable.  (valid but has already been spent)\n"),
             false => println!("\nThis DBC is spendable.   (valid and has not been spent)\n"),
@@ -618,7 +618,7 @@ fn prepare_tx(mintinfo: &MintInfo) -> Result<RingCtTransactionRevealed> {
 
     // Get outputs from user
     // note, we upcast to i128 to allow negative value.
-    // This permits unbalanced inputs/outputs to reach sn_dbc layer for validation.
+    // This permits unbalanced inputs/outputs to reach sn_dbc layer for verification.
     let inputs_amount_sum = tx_builder.inputs_amount_sum();
     while inputs_amount_sum as i128 - tx_builder.outputs_amount_sum() as i128 > 0 {
         println!();

--- a/src/amount_secrets.rs
+++ b/src/amount_secrets.rs
@@ -13,7 +13,6 @@ use blsttc::{
 };
 use rand_core::RngCore;
 use std::collections::BTreeMap;
-use std::convert::Into;
 use std::convert::TryFrom;
 
 use crate::{Amount, BlindingFactor, Error, SecretKeyBlst};
@@ -123,19 +122,17 @@ impl From<(Amount, BlindingFactor)> for AmountSecrets {
     }
 }
 
-#[allow(clippy::from_over_into)]
-impl Into<RevealedCommitment> for AmountSecrets {
-    /// convert AmountSecrets into the inner RevealedCommitment
-    fn into(self) -> RevealedCommitment {
-        self.0
+impl From<AmountSecrets> for RevealedCommitment {
+    /// convert AmountSecrets into RevealedCommitment
+    fn from(a: AmountSecrets) -> RevealedCommitment {
+        a.0
     }
 }
 
-#[allow(clippy::from_over_into)]
-impl Into<Amount> for AmountSecrets {
+impl From<AmountSecrets> for Amount {
     /// convert AmountSecrets into an Amount
-    fn into(self) -> Amount {
-        self.0.value()
+    fn from(a: AmountSecrets) -> Amount {
+        a.0.value()
     }
 }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -632,7 +632,7 @@ pub mod mock {
             let reissue_request = rr_builder.build()?;
 
             for mint_node in self.mint_nodes.into_iter() {
-                // note: for our (mock) purposes, all spentbook nodes are validated to
+                // note: for our (mock) purposes, all spentbook nodes are verified to
                 // have the same public key.  (in the same section)
                 let spentbook_node_arbitrary = &self.spentbook_nodes[0];
                 let mint_node = mint_node.trust_spentbook_public_key(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ mod mint;
 mod owner;
 mod spent_proof;
 mod spentbook;
-mod validation;
+mod verification;
 
 pub use crate::{
     amount_secrets::AmountSecrets,
@@ -42,7 +42,7 @@ pub use crate::{
     owner::{DerivationIndex, Owner, OwnerOnce},
     spent_proof::{SpentProof, SpentProofContent, SpentProofShare},
     spentbook::SpentBookNodeMock,
-    validation::TransactionValidator,
+    verification::TransactionVerifier,
 };
 
 #[cfg(feature = "serde")]

--- a/src/spent_proof.rs
+++ b/src/spent_proof.rs
@@ -170,14 +170,14 @@ impl SpentProof {
         bytes
     }
 
-    /// validate this SpentProof
+    /// verify this SpentProof
     ///
     /// checks that the input transaction hash matches the tx_hash that was
-    /// signed by the spentbook and validates that spentbook signature is
+    /// signed by the spentbook and verifies that spentbook signature is
     /// valid for this SpentProof.
     ///
     /// note that the verifier must already hold (trust) the spentbook's public key.
-    pub fn validate<K: KeyManager>(&self, tx_hash: Hash, verifier: &K) -> Result<()> {
+    pub fn verify<K: KeyManager>(&self, tx_hash: Hash, verifier: &K) -> Result<()> {
         // verify input tx_hash matches our tx_hash which was signed by spentbook.
         if tx_hash != self.content.transaction_hash {
             return Err(Error::InvalidTransactionHash);


### PR DESCRIPTION
High level changes:

1. The check that secret amount matches commitment is now moved inside
Dbc::verify() so there is no chance of a wallet forgetting to do it.

2. We standardize on verify/verification instead of validate/validation.
This matches usage in ringct and blsttc, so it makes the api more
regular.

Details:

* change validate command to verify in mint-repl
* impl From<AmountSecrets> instead of Into<RevealedCommitment>
* impl From<AmountSecrets> instead of Into<Amount>
* replace validate/validation with verify/verification in code/comments
* rename validation.rs to verification.rs
* rename TransactionValidator to TransactionVerifier
* rename Dbc::confirm_valid() to verify()
* verify that secret Amount matches public Commitment inside Dbc::verify()
* update tests appropriately