### PR TITLE
Builder verification pr

### DIFF
--- a/benches/reissue.rs
+++ b/benches/reissue.rs
@@ -108,7 +108,7 @@ fn bench_reissue_100_to_1(c: &mut Criterion) {
     let reissue_share = mintnode.reissue(rr).unwrap();
 
     dbc_builder = dbc_builder.add_reissue_share(reissue_share);
-    let dbcs = dbc_builder.build().unwrap();
+    let dbcs = dbc_builder.build(mintnode.key_manager()).unwrap();
 
     let output_owner_once =
         OwnerOnce::from_owner_base(Owner::from_random_secret_key(&mut rng), &mut rng8);
@@ -187,7 +187,11 @@ fn generate_dbc_of_value(
 
     let reissue_share = mint_node.reissue(rr)?;
     dbc_builder = dbc_builder.add_reissue_share(reissue_share);
-    let (starting_dbc, ..) = dbc_builder.build()?.into_iter().next().unwrap();
+    let (starting_dbc, ..) = dbc_builder
+        .build(mint_node.key_manager())?
+        .into_iter()
+        .next()
+        .unwrap();
 
     Ok((mint_node, spentbook_node, starting_dbc))
 }

--- a/examples/mint-repl/mint-repl.rs
+++ b/examples/mint-repl/mint-repl.rs
@@ -843,7 +843,7 @@ fn reissue_auto_cli(mintinfo: &mut MintInfo) -> Result<()> {
         for mint_node in mintinfo.mintnodes.iter() {
             dbc_builder = dbc_builder.add_reissue_share(mint_node.reissue(rr.clone())?);
         }
-        let outputs = dbc_builder.build()?;
+        let outputs = dbc_builder.build(mintinfo.mintnodes[0].key_manager())?;
         let output_dbcs: Vec<Dbc> = outputs.into_iter().map(|(dbc, ..)| dbc).collect();
 
         for dbc in input_dbcs.iter() {
@@ -895,7 +895,7 @@ fn reissue(mintinfo: &mut MintInfo, reissue_request: ReissueRequestRevealed) -> 
         dbc_builder = dbc_builder.add_reissue_share(reissue_share);
     }
 
-    let output_dbcs = dbc_builder.build()?;
+    let output_dbcs = dbc_builder.build(mintinfo.mintnodes[0].key_manager())?;
 
     // for each output, construct Dbc and display
     for (dbc, _owner_once, _amount_secrets) in output_dbcs.iter() {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -343,14 +343,14 @@ impl DbcBuilder {
 
     /// Build the output DBCs
     ///
-    /// This function relies/assumes that the caller (wallet/client) obtains
-    /// the mint's and spentbook's public keys (held by KeyManager) in a
-    /// trustless/verified way.  ie, the caller should not simply obtain keys
-    /// from a MintNode directly, but must somehow verify that the MintNode is
-    /// a valid authority.
+    /// note: common tx verification logic is shared by MintNode::reissue(),
+    /// DbcBuilder::build() and Dbc::verify()
+    ///
+    /// see TransactionVerifier::verify() for a description of
+    /// verifier requirements.
     pub fn build<K: KeyManager>(
         self,
-        mint_verifier: &K,
+        verifier: &K,
     ) -> Result<Vec<(Dbc, OwnerOnce, AmountSecrets)>> {
         let mut mint_sig_shares: Vec<NodeSignature> = Default::default();
         let mut pk_set: HashSet<PublicKeySet> = Default::default();
@@ -411,7 +411,7 @@ impl DbcBuilder {
 
         // verify the Tx, along with mint sigs and spent proofs.
         // note that we do this just once for entire Tx, not once per output Dbc.
-        TransactionVerifier::verify(mint_verifier, transaction, &mint_sigs, spent_proofs)?;
+        TransactionVerifier::verify(verifier, transaction, &mint_sigs, spent_proofs)?;
 
         let pc_gens = PedersenGens::default();
         let output_commitments: Vec<(Commitment, RevealedCommitment)> = self

--- a/src/error.rs
+++ b/src/error.rs
@@ -54,26 +54,11 @@ pub enum Error {
     #[error("The number of SpentProof does not match the number of input MlsagSignature")]
     SpentProofInputMismatch,
 
-    #[error("The PublicKeySet differs between ReissueRequest entries")]
-    ReissueRequestPublicKeySetMismatch,
-
-    #[error("The Public Commitments differ between ReissueRequest entries")]
-    ReissueRequestPublicCommitmentMismatch,
-
     #[error("We need at least one spent proof share for {0:?} to build a SpentProof")]
     ReissueRequestMissingSpentProofShare(KeyImage),
 
     #[error("The PublicKeySet differs between ReissueShare entries")]
     ReissueSharePublicKeySetMismatch,
-
-    #[error("The MintNodeSignature count in ReissueShare differs from input count in ReissueTransaction")]
-    ReissueShareMintNodeSignaturesLenMismatch,
-
-    #[error("MintNodeSignature not found for an input in ReissueTransaction")]
-    ReissueShareMintNodeSignatureNotFoundForInput,
-
-    #[error("No reissue shares")]
-    NoReissueShares,
 
     #[error("Decryption failed")]
     DecryptionBySecretKeyFailed,

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,9 +24,6 @@ pub enum Error {
     #[error("An error occured when signing {0}")]
     Signing(String),
 
-    #[error("This input has a signature, but it doesn't appear in the transaction")]
-    UnknownInput,
-
     #[error("Failed signature check.")]
     FailedSignature,
 
@@ -35,6 +32,9 @@ pub enum Error {
 
     #[error("At least one transaction input is missing a signature.")]
     MissingSignatureForInput,
+
+    #[error("The number of mint signatures does not match the number of transaction inputs.")]
+    MintSignatureInputMismatch,
 
     #[error("Invalid SpentProof Signature for {0:?}")]
     InvalidSpentProofSignature(KeyImage),

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -262,7 +262,7 @@ mod tests {
 
         // Aggregate ReissueShare to build output DBCs
         dbc_builder = dbc_builder.add_reissue_share(reissue_share);
-        let output_dbcs = dbc_builder.build()?;
+        let output_dbcs = dbc_builder.build(mint_node.key_manager())?;
 
         for (dbc, owner_once, amount_secrets) in output_dbcs.iter() {
             let dbc_amount = amount_secrets.amount();
@@ -387,7 +387,7 @@ mod tests {
 
         // Aggregate ReissueShare to build output DBCs
         dbc_builder = dbc_builder.add_reissue_share(reissue_share);
-        let output_dbcs = dbc_builder.build()?;
+        let output_dbcs = dbc_builder.build(mint_node.key_manager())?;
 
         // The outputs become inputs for next reissue.
         let inputs_dbcs: Vec<(Dbc, SecretKey, Vec<DecoyInput>)> = output_dbcs
@@ -534,7 +534,7 @@ mod tests {
 
                 // Aggregate ReissueShare to build output DBCs
                 dbc_builder = dbc_builder.add_reissue_share(rs);
-                let output_dbcs = dbc_builder.build()?;
+                let output_dbcs = dbc_builder.build(mint_node.key_manager())?;
 
                 for (dbc, owner_once, _amount_secrets) in output_dbcs.iter() {
                     let dbc_confirm_result = dbc.verify(
@@ -703,7 +703,7 @@ mod tests {
 
         // Aggregate ReissueShare to build output DBCs
         dbc_builder = dbc_builder.add_reissue_share(reissue_share);
-        let output_dbcs = dbc_builder.build()?;
+        let output_dbcs = dbc_builder.build(mint_node.key_manager())?;
         let (b_dbc, ..) = &output_dbcs[0];
 
         // ----------

--- a/src/verification.rs
+++ b/src/verification.rs
@@ -47,14 +47,14 @@ impl TransactionVerifier {
     ) -> Result<(), Error> {
         // Do quick checks first to reduce potential DOS vectors.
 
-        if mint_sigs.len() < transaction.mlsags.len() {
-            return Err(Error::MissingSignatureForInput);
+        if mint_sigs.len() != transaction.mlsags.len() {
+            return Err(Error::MintSignatureInputMismatch);
         }
 
         // Verify that we received a mint pk/sig for each tx input.
         for mlsag in transaction.mlsags.iter() {
             if mint_sigs.get(&mlsag.key_image.into()).is_none() {
-                return Err(Error::UnknownInput);
+                return Err(Error::MissingSignatureForInput);
             }
         }
 


### PR DESCRIPTION
fix: verify Tx in DbcBuilder::build()

Previously DbcBuilder::build() was only doing some incomplete
validations.  This commit verifies the Tx which also requires
that DbcBuilder::build() accept a KeyManager param, which has
mintnode/spentbooknode trust implications/requirements that
are now documented.

* doc: add doc comment for TransactionVerifier::verify() and
        ::verify_without_sigs()
* rename mint_verifier param to verifier
* doc: add doc comment for Dbc::verify()
* optimization: iter/collect() mint sigs once per tx, not per Dbc
* add KeyManager arg to DbcBuilder::build()
* call TransactionVerifier::verify() within DbcBuilder::build()
* adapt tests, examples, benches to pass key_manager into ::build()

------
fix: avoid unnecessary sig verifications

Previously we were performing duplicate signature verifications.

This occurred whenever two or more inputs to our tx (b) were each outputs of the
same source tx (a). In this case, KeyManager::verify() was being called using
the exact same tx_hash, mint_pk, and mint_sig for each input.

The change is to:
1. separate logic that verifies a mint sig is provided for each
tx from the logic that actually verifies each sig.
2. generate a list of unique pk+sig.
3. verify tx hash against each pk+sig.
