### PR TITLE
fix: verify that ReissueShare match

### DIFF
--- a/src/dbc.rs
+++ b/src/dbc.rs
@@ -462,11 +462,9 @@ pub(crate) mod tests {
 
         assert_eq!(reissue_tx.hash(), reissue_share.transaction.hash());
 
-        let (mint_key_set, mint_sig_share) =
-            &reissue_share.mint_node_signatures.values().next().unwrap();
-
-        let mint_sig = mint_key_set
-            .combine_signatures(vec![mint_sig_share.threshold_crypto()])
+        let mint_sig = reissue_share
+            .mint_public_key_set
+            .combine_signatures(vec![reissue_share.mint_signature_share.threshold_crypto()])
             .unwrap();
 
         // We must obtain the RevealedCommitment for our output in order to
@@ -501,10 +499,11 @@ pub(crate) mod tests {
         let mint_pk = mint_node.key_manager().public_key_set()?.public_key();
         fuzzed_mint_sigs.extend(
             reissue_share
-                .mint_node_signatures
-                .into_keys()
+                .transaction
+                .mlsags
+                .iter()
                 .take(n_valid_sigs.coerce())
-                .map(|in_owner| (in_owner, (mint_pk, mint_sig.clone()))),
+                .map(|m| (m.key_image.into(), (mint_pk, mint_sig.clone()))),
         );
 
         let mut repeating_inputs = reissue_tx

--- a/src/error.rs
+++ b/src/error.rs
@@ -57,8 +57,8 @@ pub enum Error {
     #[error("We need at least one spent proof share for {0:?} to build a SpentProof")]
     ReissueRequestMissingSpentProofShare(KeyImage),
 
-    #[error("The PublicKeySet differs between ReissueShare entries")]
-    ReissueSharePublicKeySetMismatch,
+    #[error("ReissueShare do not match")]
+    ReissueShareMismatch,
 
     #[error("Decryption failed")]
     DecryptionBySecretKeyFailed,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,10 +35,10 @@ pub use crate::{
     error::{Error, Result},
     genesis::GenesisMaterial,
     key_manager::{
-        KeyManager, NodeSignature, PublicKey, PublicKeySet, Signature, SimpleKeyManager,
+        IndexedSignatureShare, KeyManager, PublicKey, PublicKeySet, Signature, SimpleKeyManager,
         SimpleSigner,
     },
-    mint::{MintNode, MintNodeSignatures, ReissueRequest, ReissueShare},
+    mint::{MintNode, ReissueRequest, ReissueShare},
     owner::{DerivationIndex, Owner, OwnerOnce},
     spent_proof::{SpentProof, SpentProofContent, SpentProofShare},
     spentbook::SpentBookNodeMock,

--- a/src/spent_proof.rs
+++ b/src/spent_proof.rs
@@ -7,8 +7,8 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::{
-    Commitment, Error, Hash, KeyImage, KeyManager, NodeSignature, PublicKey, PublicKeySet, Result,
-    Signature,
+    Commitment, Error, Hash, IndexedSignatureShare, KeyImage, KeyManager, PublicKey, PublicKeySet,
+    Result, Signature,
 };
 
 use std::cmp::Ordering;
@@ -71,7 +71,7 @@ pub struct SpentProofShare {
 
     /// The Spentbook who notarized that this DBC was spent.
     pub spentbook_pks: PublicKeySet,
-    pub spentbook_sig_share: NodeSignature,
+    pub spentbook_sig_share: IndexedSignatureShare,
 }
 
 // impl manually to avoid clippy complaint about Hash conflict.
@@ -109,7 +109,7 @@ impl SpentProofShare {
     }
 
     /// get spentbook's signature share
-    pub fn spentbook_sig_share(&self) -> &NodeSignature {
+    pub fn spentbook_sig_share(&self) -> &IndexedSignatureShare {
         &self.spentbook_sig_share
     }
 


### PR DESCRIPTION
We modify ReissueShare to facilitate verifying that common fields are the same between all mint nodes. (All fields except sig-share must match.)

We also remove from ReissueShare an unnecessary Vec of redundant MintNodeSignature keyed by input KeyImage.  All MintNodeSignature were signing the same Tx, so only one copy is needed.

The above changes enable DbcBuilder::build() to be simplified quite a bit, and it is more correct because now it verifies that all common fields of all ReissueShare are equal.

While we are at it, we do a bit of cleanup/normalization of the API such as renaming NodeSignature to IndexedSignatureShare.

* remove: MintNodeSignature
* remove: MintNodeSignatures
* modify ReissueShare fields
* NodeSignature --> IndexedSignatureShare
* add ReissueShare::to_common_bytes()
* fix: DbcBuilder now correctly checks that ReissueShares match
* Error::ReissueSharePublicKeySetMismatch --> ReissueShareMismatch
* update tests