### PR TITLE
integrate blsttc/blstrs and remove mint::*

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ ringct-serde = [ "blst_ringct/serde" ]
 thiserror = "1.0.24"
 quickcheck_macros = "1"
 rand = "0.8.0"
-# blsttc = "3.3.0"
 blsttc = {git = "https://github.com/dan-da/blsttc", branch = "sn_dbc_integration"}
 hex = "0.4.3"
 rand_core = "0.6.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ ringct-serde = [ "blst_ringct/serde" ]
 [dependencies]
 thiserror = "1.0.24"
 quickcheck_macros = "1"
-rand = "0.7.1"
+rand = "0.8.0"
 # blsttc = "3.3.0"
 blsttc = {git = "https://github.com/dan-da/blsttc", branch = "sn_dbc_integration"}
 hex = "0.4.3"
@@ -40,10 +40,6 @@ xor_name = {git = "https://github.com/iancoleman/xor_name", branch = "remove_osr
   git = "https://github.com/davidrusu/blst-bulletproofs.git"
   branch = "bls12-381-curve"
 
-  [dependencies.rand8]
-  package = "rand"
-  version = "0.8.0"
-
   [dependencies.bls_dkg]
   git = "https://github.com/dan-da/bls_dkg.git"
   branch = "sn_dbc_integration"
@@ -61,7 +57,7 @@ xor_name = {git = "https://github.com/iancoleman/xor_name", branch = "remove_osr
 
 [dev-dependencies]
 anyhow = "1.0.40"
-rand = "0.7.1"
+rand = "0.8.0"
 rustyline = "8.0.0"
 bincode = "1.3.3"
 criterion = "0.3.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ rand = "0.8.0"
 rustyline = "8.0.0"
 bincode = "1.3.3"
 criterion = "0.3.5"
+pprof = {version = "0.7.0", features = ["flamegraph"]}
 
   [dev-dependencies.sn_dbc]
   path = "."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,12 @@ ringct-serde = [ "blst_ringct/serde" ]
 thiserror = "1.0.24"
 quickcheck_macros = "1"
 rand = "0.7.1"
-blsttc = "3.3.0"
+# blsttc = "3.3.0"
+blsttc = {git = "https://github.com/dan-da/blsttc", branch = "sn_dbc_integration"}
 hex = "0.4.3"
 rand_core = "0.6.3"
-xor_name = "3.1.0"
+# xor_name = "3.1.0"
+xor_name = {git = "https://github.com/iancoleman/xor_name", branch = "remove_osrng"}
 
   [dependencies.quickcheck]
   git = "https://github.com/davidrusu/quickcheck.git"
@@ -43,7 +45,9 @@ xor_name = "3.1.0"
   version = "0.8.0"
 
   [dependencies.bls_dkg]
-  version = "~0.9"
+  git = "https://github.com/dan-da/bls_dkg.git"
+  branch = "sn_dbc_integration"
+  version = "~0.9.1"
   optional = true
 
   [dependencies.tiny-keccak]

--- a/benches/reissue.rs
+++ b/benches/reissue.rs
@@ -50,9 +50,17 @@ fn bench_reissue_1_to_100(c: &mut Criterion) {
     let rr = rr_builder.build().unwrap();
 
     c.bench_function(&format!("reissue split 1 to {}", N_OUTPUTS), |b| {
+        let guard = pprof::ProfilerGuard::new(100).unwrap();
+
         b.iter(|| {
             mintnode.reissue(black_box(rr.clone())).unwrap();
-        })
+        });
+
+        if let Ok(report) = guard.report().build() {
+            let file =
+                std::fs::File::create(&format!("reissue_split_1_to_{}.svg", N_OUTPUTS)).unwrap();
+            report.flamegraph(file).unwrap();
+        };
     });
 }
 
@@ -120,9 +128,17 @@ fn bench_reissue_100_to_1(c: &mut Criterion) {
     let merge_rr = merge_rr_builder.build().unwrap();
 
     c.bench_function(&format!("reissue merge {} to 1", N_OUTPUTS), |b| {
+        let guard = pprof::ProfilerGuard::new(100).unwrap();
+
         b.iter(|| {
             mintnode.reissue(black_box(merge_rr.clone())).unwrap();
-        })
+        });
+
+        if let Ok(report) = guard.report().build() {
+            let file =
+                std::fs::File::create(&format!("reissue_merge_{}_to_1.svg", N_OUTPUTS)).unwrap();
+            report.flamegraph(file).unwrap();
+        };
     });
 }
 

--- a/benches/reissue.rs
+++ b/benches/reissue.rs
@@ -14,12 +14,12 @@ use sn_dbc::{
 };
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use rand8::SeedableRng as SeedableRng8;
+use rand::SeedableRng as SeedableRng8;
 
 const N_OUTPUTS: u32 = 100;
 
 fn bench_reissue_1_to_100(c: &mut Criterion) {
-    let mut rng8 = rand8::rngs::StdRng::from_seed([0u8; 32]);
+    let mut rng8 = rand::rngs::StdRng::from_seed([0u8; 32]);
 
     let (mintnode, mut spentbook, starting_dbc) =
         generate_dbc_of_value(N_OUTPUTS as Amount, &mut rng8).unwrap();
@@ -57,7 +57,7 @@ fn bench_reissue_1_to_100(c: &mut Criterion) {
 }
 
 fn bench_reissue_100_to_1(c: &mut Criterion) {
-    let mut rng8 = rand8::rngs::StdRng::from_seed([0u8; 32]);
+    let mut rng8 = rand::rngs::StdRng::from_seed([0u8; 32]);
     let num_decoys = 0;
 
     let (mintnode, mut spentbook, starting_dbc) =
@@ -128,7 +128,7 @@ fn bench_reissue_100_to_1(c: &mut Criterion) {
 
 fn generate_dbc_of_value(
     amount: Amount,
-    rng8: &mut (impl rand8::RngCore + rand_core::CryptoRng),
+    rng8: &mut (impl rand::RngCore + rand_core::CryptoRng),
 ) -> Result<(MintNode<SimpleKeyManager>, SpentBookNodeMock, Dbc)> {
     let (mint_node, mut spentbook_node, genesis_dbc, _genesis_material, _amount_secrets) =
         GenesisBuilderMock::init_genesis_single(rng8)?;

--- a/benches/reissue.rs
+++ b/benches/reissue.rs
@@ -13,8 +13,6 @@ use sn_dbc::{
     SpentBookNodeMock,
 };
 
-use blst_ringct::Output;
-
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use rand8::SeedableRng as SeedableRng8;
 
@@ -37,13 +35,10 @@ fn bench_reissue_1_to_100(c: &mut Criterion) {
             vec![], // never any decoys for genesis
             &mut rng8,
         )
-        .add_outputs((0..N_OUTPUTS).into_iter().map(|_| {
+        .add_outputs_by_amount((0..N_OUTPUTS).into_iter().map(|_| {
             let owner_once =
                 OwnerOnce::from_owner_base(Owner::from_random_secret_key(&mut rng8), &mut rng8);
-            (
-                Output::new(owner_once.as_owner().public_key(), 1),
-                owner_once,
-            )
+            (1, owner_once)
         }))
         .build(&mut rng8)
         .unwrap();
@@ -79,13 +74,10 @@ fn bench_reissue_100_to_1(c: &mut Criterion) {
             vec![], // never any decoy inputs for genesis
             &mut rng8,
         )
-        .add_outputs((0..N_OUTPUTS).into_iter().map(|_| {
+        .add_outputs_by_amount((0..N_OUTPUTS).into_iter().map(|_| {
             let owner_once =
                 OwnerOnce::from_owner_base(Owner::from_random_secret_key(&mut rng8), &mut rng8);
-            (
-                Output::new(owner_once.as_owner().public_key(), 1),
-                owner_once,
-            )
+            (1, owner_once)
         }))
         .build(&mut rng8)
         .unwrap();
@@ -117,13 +109,7 @@ fn bench_reissue_100_to_1(c: &mut Criterion) {
                 .collect(),
             &mut rng8,
         )
-        .add_output(
-            Output::new(
-                output_owner_once.as_owner().public_key(),
-                N_OUTPUTS as Amount,
-            ),
-            output_owner_once,
-        )
+        .add_output_by_amount(N_OUTPUTS as Amount, output_owner_once)
         .build(&mut rng8)
         .unwrap();
 
@@ -156,12 +142,9 @@ fn generate_dbc_of_value(
             vec![], // never any decoys for genesis
             rng8,
         )
-        .add_outputs(output_amounts.into_iter().map(|amount| {
+        .add_outputs_by_amount(output_amounts.into_iter().map(|amount| {
             let owner_once = OwnerOnce::from_owner_base(Owner::from_random_secret_key(rng8), rng8);
-            (
-                Output::new(owner_once.as_owner().public_key(), amount),
-                owner_once,
-            )
+            (amount, owner_once)
         }))
         .build(rng8)?;
 

--- a/examples/mint-repl/mint-repl.rs
+++ b/examples/mint-repl/mint-repl.rs
@@ -579,7 +579,6 @@ fn verify(mintinfo: &MintInfo) -> Result<()> {
 
 /// Implements prepare_tx command.
 fn prepare_tx(mintinfo: &MintInfo) -> Result<RingCtTransactionRevealed> {
-    let mut rng = rand::thread_rng();
     let mut rng8 = rand8::thread_rng();
     let mut tx_builder: TransactionBuilder = Default::default();
 
@@ -668,7 +667,7 @@ fn prepare_tx(mintinfo: &MintInfo) -> Result<RingCtTransactionRevealed> {
                             Some(Owner::from(public_key))
                         }
                     },
-                    "r" => Some(Owner::from_random_secret_key(&mut rng)),
+                    "r" => Some(Owner::from_random_secret_key(&mut rng8)),
                     "c" => return Err(anyhow!("Cancelled")),
                     _ => None,
                 };
@@ -680,10 +679,7 @@ fn prepare_tx(mintinfo: &MintInfo) -> Result<RingCtTransactionRevealed> {
         let owner_once = OwnerOnce::from_owner_base(owner_base, &mut rng8);
 
         tx_builder = tx_builder.add_output(
-            Output {
-                amount,
-                public_key: owner_once.as_owner().public_key_blst(),
-            },
+            Output::new(owner_once.as_owner().public_key(), amount),
             owner_once,
         );
 
@@ -819,13 +815,10 @@ fn reissue_auto_cli(mintinfo: &mut MintInfo) -> Result<()> {
             let amount = rng.gen_range(0, range_max);
 
             let owner_once =
-                OwnerOnce::from_owner_base(Owner::from_random_secret_key(&mut rng), &mut rng8);
+                OwnerOnce::from_owner_base(Owner::from_random_secret_key(&mut rng8), &mut rng8);
 
             tx_builder = tx_builder.add_output(
-                Output {
-                    amount,
-                    public_key: owner_once.as_owner().public_key_blst(),
-                },
+                Output::new(owner_once.as_owner().public_key(), amount),
                 owner_once,
             );
         }
@@ -909,7 +902,7 @@ fn reissue(mintinfo: &mut MintInfo, reissue_request: ReissueRequestRevealed) -> 
 
 /// Makes a new random SecretKeySet
 fn mk_secret_key_set(threshold: usize) -> Result<(Poly, SecretKeySet)> {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand8::thread_rng();
     let poly = Poly::try_random(threshold, &mut rng).map_err(|e| anyhow!(e))?;
     Ok((poly.clone(), SecretKeySet::from(poly)))
 }

--- a/examples/mint-repl/mint-repl.rs
+++ b/examples/mint-repl/mint-repl.rs
@@ -24,9 +24,8 @@ use rustyline::error::ReadlineError;
 use rustyline::Editor;
 use serde::{Deserialize, Serialize};
 use sn_dbc::{
-    Amount, Dbc, DbcBuilder, GenesisBuilderMock, MintNode, Output, OutputOwnerMap, Owner,
-    OwnerOnce, ReissueRequest, ReissueRequestBuilder, SimpleKeyManager, SpentBookNodeMock,
-    TransactionBuilder,
+    Amount, Dbc, DbcBuilder, GenesisBuilderMock, MintNode, OutputOwnerMap, Owner, OwnerOnce,
+    ReissueRequest, ReissueRequestBuilder, SimpleKeyManager, SpentBookNodeMock, TransactionBuilder,
 };
 use std::collections::{BTreeMap, HashMap};
 use std::iter::FromIterator;
@@ -678,10 +677,7 @@ fn prepare_tx(mintinfo: &MintInfo) -> Result<RingCtTransactionRevealed> {
 
         let owner_once = OwnerOnce::from_owner_base(owner_base, &mut rng8);
 
-        tx_builder = tx_builder.add_output(
-            Output::new(owner_once.as_owner().public_key(), amount),
-            owner_once,
-        );
+        tx_builder = tx_builder.add_output_by_amount(amount, owner_once);
 
         i += 1;
     }
@@ -817,10 +813,7 @@ fn reissue_auto_cli(mintinfo: &mut MintInfo) -> Result<()> {
             let owner_once =
                 OwnerOnce::from_owner_base(Owner::from_random_secret_key(&mut rng8), &mut rng8);
 
-            tx_builder = tx_builder.add_output(
-                Output::new(owner_once.as_owner().public_key(), amount),
-                owner_once,
-            );
+            tx_builder = tx_builder.add_output_by_amount(amount, owner_once);
         }
 
         let (mut rr_builder, mut dbc_builder, _material) = tx_builder.build(&mut rng8)?;

--- a/src/amount_secrets.rs
+++ b/src/amount_secrets.rs
@@ -6,6 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use crate::{BlindingFactor, Error};
 use blst_ringct::RevealedCommitment;
 use blsttc::{
     Ciphertext, DecryptionShare, IntoFr, PublicKey, PublicKeySet, SecretKey, SecretKeySet,
@@ -15,7 +16,8 @@ use rand_core::RngCore;
 use std::collections::BTreeMap;
 use std::convert::TryFrom;
 
-use crate::{Amount, BlindingFactor, Error, SecretKeyBlst};
+// we re-export this.
+pub use blst_ringct::ringct::Amount;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -43,7 +45,7 @@ impl AmountSecrets {
     }
 
     /// blinding factor getter
-    pub fn blinding_factor(&self) -> SecretKeyBlst {
+    pub fn blinding_factor(&self) -> BlindingFactor {
         self.0.blinding
     }
 

--- a/src/blst.rs
+++ b/src/blst.rs
@@ -6,129 +6,27 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-//! This module defines blstrs aliases, wrappers, and helpers.
-//!
-//! blstrs types Scalar and G1Affine are used to represent distinct concepts
-//! in ringct such as:
-//!   Scalar:    SecretKey, BlindingFactor
-//!   G1Affine:  Commitment, PublicKey, KeyImage
+//! This module defines blstrs aliases
 //!
 //! We provide type aliases to make the usage in each context clearer and to make the
 //! the sn_dbc public API simpler so that the caller should not need to depend on blstrs
 //! and use its types directly.
 //!
-//! Even sn_dbc uses the type aliases rather than directly using the blstrs types.
+//! sn_dbc internally uses the type aliases rather than directly using the blstrs types.
 //!
 //! We could consider moving some or all of this lower into blst_ringct to make these
 //! crates consistent.
 
-use blstrs::group::{Curve, Group};
-use blstrs::{G1Affine, G1Projective, Scalar};
-use std::cmp::Ordering;
-use std::hash::{Hash, Hasher};
-
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-
-/// a SecretKey in Blst format
-// pub type SecretKeyBlst = Scalar;
-
-/// a PublicKey in Blst format
-// pub type PublicKeyBlst = G1Affine;
-
 /// a Commitment
-pub type Commitment = G1Affine;
+pub type Commitment = blstrs::G1Affine;
 
 /// a BlindingFactor
-pub type BlindingFactor = Scalar;
+pub type BlindingFactor = blstrs::Scalar;
 
-/// A KeyImage, which is derived from pk and sk
-pub type KeyImage = PublicKeyBlstMappable;
-
-// This is a NewType wrapper for blstrs::G1Affine because in places we
-// need to use it as a key in a BTreeMap.
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, Copy)]
-pub struct PublicKeyBlstMappable(G1Affine);
-
-impl PublicKeyBlstMappable {
-    pub fn to_bytes(&self) -> [u8; 48] {
-        self.0.to_compressed()
-    }
-
-    pub fn random(rng: &mut impl rand8::RngCore) -> Self {
-        Self(G1Projective::random(rng).to_affine())
-    }
-}
-
-impl PartialEq for KeyImage {
-    fn eq(&self, other: &Self) -> bool {
-        self.0.to_compressed() == other.0.to_compressed()
-    }
-}
-
-impl AsRef<G1Affine> for KeyImage {
-    fn as_ref(&self) -> &G1Affine {
-        &self.0
-    }
-}
-
-impl Eq for PublicKeyBlstMappable {}
-
-impl PartialOrd for KeyImage {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for PublicKeyBlstMappable {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.0.to_compressed().cmp(&other.0.to_compressed())
-    }
-}
-
-impl Hash for PublicKeyBlstMappable {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        let bytes = self.0.to_compressed();
-        bytes.hash(state);
-    }
-}
-
-impl From<G1Affine> for PublicKeyBlstMappable {
-    fn from(k: G1Affine) -> Self {
-        Self(k)
-    }
-}
-
-// temporary: should go away once blsttc is integrated with with blstrs
-// For this reason, we allow unwrap() in these methods so that
-// it doesn't force higher APIs to return a Result when they should
-// not need to do so once the integration is complete.
-// pub struct BlsHelper {}
-
-// impl BlsHelper {
-//     #[allow(dead_code)]
-//     pub fn blsttc_to_blstrs_secret_key(sk: SecretKey) -> SecretKeyBlst {
-//         let bytes = sk.to_bytes();
-//         // fixme: unwrap
-//         SecretKeyBlst::from_bytes_be(&bytes).unwrap()
-//     }
-
-//     pub fn blsttc_to_blstrs_public_key(pk: &PublicKey) -> PublicKeyBlst {
-//         let bytes = pk.to_bytes();
-//         // fixme: unwrap
-//         PublicKeyBlst::from_compressed(&bytes).unwrap()
-//     }
-
-//     pub fn blstrs_to_blsttc_public_key(pk: &PublicKeyBlst) -> PublicKey {
-//         let bytes = pk.to_compressed();
-//         // fixme: unwrap
-//         PublicKey::from_bytes(bytes).unwrap()
-//     }
-
-//     pub fn blstrs_to_blsttc_secret_key(sk: SecretKeyBlst) -> SecretKey {
-//         let bytes = sk.to_bytes_be();
-//         // fixme: unwrap
-//         SecretKey::from_bytes(bytes).unwrap()
-//     }
-// }
+/// A KeyImage can be thought of as a specific type
+/// of public key. blsttc::PublicKey is a newtype
+/// wrapper around blstrs::G1Affine.  We use
+/// PublicKey because it impls Hash and Ord traits
+/// that are useful for storing the KeyImage in
+/// a map.
+pub type KeyImage = blsttc::PublicKey;

--- a/src/blst.rs
+++ b/src/blst.rs
@@ -27,16 +27,14 @@ use blstrs::{G1Affine, G1Projective, Scalar};
 use std::cmp::Ordering;
 use std::hash::{Hash, Hasher};
 
-use blsttc::{PublicKey, SecretKey};
-
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// a SecretKey in Blst format
-pub type SecretKeyBlst = Scalar;
+// pub type SecretKeyBlst = Scalar;
 
 /// a PublicKey in Blst format
-pub type PublicKeyBlst = G1Affine;
+// pub type PublicKeyBlst = G1Affine;
 
 /// a Commitment
 pub type Commitment = G1Affine;
@@ -106,31 +104,31 @@ impl From<G1Affine> for PublicKeyBlstMappable {
 // For this reason, we allow unwrap() in these methods so that
 // it doesn't force higher APIs to return a Result when they should
 // not need to do so once the integration is complete.
-pub struct BlsHelper {}
+// pub struct BlsHelper {}
 
-impl BlsHelper {
-    #[allow(dead_code)]
-    pub fn blsttc_to_blstrs_secret_key(sk: SecretKey) -> SecretKeyBlst {
-        let bytes = sk.to_bytes();
-        // fixme: unwrap
-        SecretKeyBlst::from_bytes_be(&bytes).unwrap()
-    }
+// impl BlsHelper {
+//     #[allow(dead_code)]
+//     pub fn blsttc_to_blstrs_secret_key(sk: SecretKey) -> SecretKeyBlst {
+//         let bytes = sk.to_bytes();
+//         // fixme: unwrap
+//         SecretKeyBlst::from_bytes_be(&bytes).unwrap()
+//     }
 
-    pub fn blsttc_to_blstrs_public_key(pk: &PublicKey) -> PublicKeyBlst {
-        let bytes = pk.to_bytes();
-        // fixme: unwrap
-        PublicKeyBlst::from_compressed(&bytes).unwrap()
-    }
+//     pub fn blsttc_to_blstrs_public_key(pk: &PublicKey) -> PublicKeyBlst {
+//         let bytes = pk.to_bytes();
+//         // fixme: unwrap
+//         PublicKeyBlst::from_compressed(&bytes).unwrap()
+//     }
 
-    pub fn blstrs_to_blsttc_public_key(pk: &PublicKeyBlst) -> PublicKey {
-        let bytes = pk.to_compressed();
-        // fixme: unwrap
-        PublicKey::from_bytes(bytes).unwrap()
-    }
+//     pub fn blstrs_to_blsttc_public_key(pk: &PublicKeyBlst) -> PublicKey {
+//         let bytes = pk.to_compressed();
+//         // fixme: unwrap
+//         PublicKey::from_bytes(bytes).unwrap()
+//     }
 
-    pub fn blstrs_to_blsttc_secret_key(sk: SecretKeyBlst) -> SecretKey {
-        let bytes = sk.to_bytes_be();
-        // fixme: unwrap
-        SecretKey::from_bytes(bytes).unwrap()
-    }
-}
+//     pub fn blstrs_to_blsttc_secret_key(sk: SecretKeyBlst) -> SecretKey {
+//         let bytes = sk.to_bytes_be();
+//         // fixme: unwrap
+//         SecretKey::from_bytes(bytes).unwrap()
+//     }
+// }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -16,14 +16,14 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 use crate::{
     AmountSecrets, Commitment, Dbc, DbcContent, Error, Hash, IndexedSignatureShare, KeyImage,
-    KeyManager, OwnerOnce, PublicKeyBlstMappable, ReissueRequest, ReissueShare, Result, SpentProof,
-    SpentProofContent, SpentProofShare, TransactionVerifier,
+    KeyManager, OwnerOnce, ReissueRequest, ReissueShare, Result, SpentProof, SpentProofContent,
+    SpentProofShare, TransactionVerifier,
 };
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-pub type OutputOwnerMap = BTreeMap<PublicKeyBlstMappable, OwnerOnce>;
+pub type OutputOwnerMap = BTreeMap<PublicKey, OwnerOnce>;
 
 /// A builder to create a RingCt transaction from
 /// inputs and outputs.

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -163,6 +163,26 @@ impl TransactionBuilder {
         self
     }
 
+    /// add an output by providing Amount and OwnerOnce
+    pub fn add_output_by_amount(mut self, amount: Amount, owner: OwnerOnce) -> Self {
+        let pk = owner.as_owner().public_key();
+        let output = Output::new(pk, amount);
+        self.output_owner_map.insert(pk, owner);
+        self.ringct_material.outputs.push(output);
+        self
+    }
+
+    /// add an output by providing iter of (Amount, OwnerOnce)
+    pub fn add_outputs_by_amount(
+        mut self,
+        outputs: impl IntoIterator<Item = (Amount, OwnerOnce)>,
+    ) -> Self {
+        for (amount, owner) in outputs.into_iter() {
+            self = self.add_output_by_amount(amount, owner);
+        }
+        self
+    }
+
     /// get a list of input owners
     pub fn input_owners(&self) -> Vec<PublicKey> {
         self.ringct_material

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -188,11 +188,7 @@ impl TransactionBuilder {
         self.ringct_material
             .public_keys()
             .iter()
-            .map(|pk| {
-                let pkg1: blsttc::G1Affine = *pk;
-                let pk: PublicKey = pkg1.into();
-                pk
-            })
+            .map(|pk| (*pk).into())
             .collect()
     }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -505,7 +505,7 @@ pub mod mock {
         pub fn gen_mint_nodes(
             mut self,
             num_nodes: usize,
-            rng: &mut impl rand8::RngCore,
+            rng: &mut impl rand::RngCore,
         ) -> Result<Self> {
             let sks = SecretKeySet::try_random(num_nodes - 1, rng)?;
             self = self.gen_mint_nodes_with_sks(num_nodes, &sks);
@@ -528,7 +528,7 @@ pub mod mock {
         pub fn gen_spentbook_nodes(
             mut self,
             num_nodes: usize,
-            rng: &mut impl rand8::RngCore,
+            rng: &mut impl rand::RngCore,
         ) -> Result<Self> {
             let sks = SecretKeySet::try_random(num_nodes - 1, rng)?;
             self = self.gen_spentbook_nodes_with_sks(num_nodes, &sks);
@@ -597,7 +597,7 @@ pub mod mock {
         #[allow(clippy::type_complexity)]
         pub fn build(
             mut self,
-            rng8: &mut (impl rand8::RngCore + rand_core::CryptoRng),
+            rng: &mut (impl rand::RngCore + rand_core::CryptoRng),
         ) -> Result<(
             Vec<MintNode<SimpleKeyManager>>,
             Vec<SpentBookNodeMock>,
@@ -616,7 +616,7 @@ pub mod mock {
                     genesis_material.ringct_material.outputs[0].clone(),
                     genesis_material.owner_once.clone(),
                 )
-                .build(rng8)?;
+                .build(rng)?;
 
             for (key_image, tx) in rr_builder.inputs() {
                 for spentbook_node in self.spentbook_nodes.iter_mut() {
@@ -668,7 +668,7 @@ pub mod mock {
         pub fn init_genesis(
             num_mint_nodes: usize,
             num_spentbook_nodes: usize,
-            rng8: &mut (impl rand8::RngCore + rand_core::CryptoRng),
+            rng: &mut (impl rand::RngCore + rand_core::CryptoRng),
         ) -> Result<(
             Vec<MintNode<SimpleKeyManager>>,
             Vec<SpentBookNodeMock>,
@@ -677,9 +677,9 @@ pub mod mock {
             AmountSecrets,
         )> {
             Self::default()
-                .gen_mint_nodes(num_mint_nodes, rng8)?
-                .gen_spentbook_nodes(num_spentbook_nodes, rng8)?
-                .build(rng8)
+                .gen_mint_nodes(num_mint_nodes, rng)?
+                .gen_spentbook_nodes(num_spentbook_nodes, rng)?
+                .build(rng)
         }
 
         /// builds and returns a single mintnode, single spentbook,
@@ -688,7 +688,7 @@ pub mod mock {
         /// the spentbook node uses a different randomly generated SecretKeySet
         #[allow(clippy::type_complexity)]
         pub fn init_genesis_single(
-            rng8: &mut (impl rand8::RngCore + rand_core::CryptoRng),
+            rng: &mut (impl rand::RngCore + rand_core::CryptoRng),
         ) -> Result<(
             MintNode<SimpleKeyManager>,
             SpentBookNodeMock,
@@ -698,9 +698,9 @@ pub mod mock {
         )> {
             let (mint_nodes, spentbook_nodes, genesis_dbc, genesis_material, amount_secrets) =
                 Self::default()
-                    .gen_mint_nodes(1, rng8)?
-                    .gen_spentbook_nodes(1, rng8)?
-                    .build(rng8)?;
+                    .gen_mint_nodes(1, rng)?
+                    .gen_spentbook_nodes(1, rng)?
+                    .build(rng)?;
 
             // Note: these unwraps are safe because the above call returned Ok.
             // We could (stylistically) avoid the unwrap eg mint_nodes[0].clone()

--- a/src/dbc.rs
+++ b/src/dbc.rs
@@ -540,10 +540,13 @@ pub(crate) mod tests {
             }
         }
 
+        use rand8::distributions::{Distribution, Standard};
+
         // Valid mint signatures for inputs not present in the transaction
         for _ in 0..n_extra_input_sigs.coerce() {
+            let secret_key: SecretKey = Standard.sample(&mut rng8);
             fuzzed_mint_sigs.insert(
-                KeyImage::random(&mut rng8),
+                secret_key.public_key(),
                 (
                     mint_node.key_manager().public_key_set()?.public_key(),
                     mint_sig.clone(),

--- a/src/dbc.rs
+++ b/src/dbc.rs
@@ -305,14 +305,7 @@ pub(crate) mod tests {
 
         let (mut rr_builder, dbc_builder, _material) = crate::TransactionBuilder::default()
             .add_input_by_secrets(dbc_owner, amount_secrets, decoy_inputs, rng8)
-            .add_outputs(divide(amount, n_ways).zip(output_owners.into_iter()).map(
-                |(amount, owner_once)| {
-                    (
-                        Output::new(owner_once.as_owner().public_key(), amount),
-                        owner_once,
-                    )
-                },
-            ))
+            .add_outputs_by_amount(divide(amount, n_ways).zip(output_owners.into_iter()))
             .build(rng8)?;
 
         for (key_image, tx) in rr_builder.inputs() {
@@ -433,10 +426,7 @@ pub(crate) mod tests {
 
         let (mut rr_builder, dbc_builder, _material) = crate::TransactionBuilder::default()
             .add_inputs_dbc(inputs, &mut rng8)?
-            .add_output(
-                Output::new(owner_once.as_owner().public_key(), amount),
-                owner_once.clone(),
-            )
+            .add_output_by_amount(amount, owner_once.clone())
             .build(&mut rng8)?;
 
         let reissue_tx = rr_builder.transaction.clone();
@@ -650,12 +640,10 @@ pub(crate) mod tests {
                 vec![], // never any decoys for genesis
                 rng8,
             )
-            .add_outputs(output_amounts.into_iter().map(|amount| {
-                let owner_once =
-                    OwnerOnce::from_owner_base(Owner::from_random_secret_key(rng8), rng8);
+            .add_outputs_by_amount(output_amounts.into_iter().map(|amount| {
                 (
-                    Output::new(owner_once.as_owner().public_key(), amount),
-                    owner_once,
+                    amount,
+                    OwnerOnce::from_owner_base(Owner::from_random_secret_key(rng8), rng8),
                 )
             }))
             .build(rng8)?;

--- a/src/dbc_content.rs
+++ b/src/dbc_content.rs
@@ -15,12 +15,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::{Error, Hash, Result};
 
-// note: Amount should move into blst_ringct crate.
-// (or else blst_ringct::RevealedCommitment should be made generic over Amount type)
-
-/// Represents a Dbc's value.
-pub type Amount = u64;
-
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct DbcContent {

--- a/src/dbc_content.rs
+++ b/src/dbc_content.rs
@@ -29,7 +29,7 @@ pub struct DbcContent {
     /// holding the SecretKey, ie the Dbc recipient that generated the PublicKey.
     ///
     /// This key is only a client/wallet concept. It is NOT actually used in the transaction
-    /// and never seen by the Mint or Spentbook.
+    /// and never seen by the Spentbook.
     ///
     /// The "real" key used in the transaction is derived from this key using a random
     /// derivation index, which is stored (encrypted) in owner_derivation_cipher.

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,23 +21,14 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 #[non_exhaustive]
 /// Node error variants.
 pub enum Error {
-    #[error("An error occured when signing {0}")]
-    Signing(String),
-
     #[error("Failed signature check.")]
     FailedSignature,
 
     #[error("Unrecognised authority.")]
     UnrecognisedAuthority,
 
-    #[error("At least one transaction input is missing a signature.")]
-    MissingSignatureForInput,
-
-    #[error("The number of mint signatures does not match the number of transaction inputs.")]
-    MintSignatureInputMismatch,
-
-    #[error("Invalid SpentProof Signature for {0:?}")]
-    InvalidSpentProofSignature(KeyImage),
+    #[error("Invalid SpentProof Signature for {0:?}.  Error: {1}")]
+    InvalidSpentProofSignature(KeyImage, String),
 
     #[error("Transaction hash does not match the transaction signed by spentbook")]
     InvalidTransactionHash,
@@ -52,13 +43,13 @@ pub enum Error {
     PublicKeyNotUniqueAcrossOutputs,
 
     #[error("The number of SpentProof does not match the number of input MlsagSignature")]
-    SpentProofInputMismatch,
+    SpentProofInputLenMismatch,
+
+    #[error("A SpentProof KeyImage does not match an MlsagSignature KeyImage")]
+    SpentProofInputKeyImageMismatch,
 
     #[error("We need at least one spent proof share for {0:?} to build a SpentProof")]
-    ReissueRequestMissingSpentProofShare(KeyImage),
-
-    #[error("ReissueShare do not match")]
-    ReissueShareMismatch,
+    MissingSpentProofShare(KeyImage),
 
     #[error("Decryption failed")]
     DecryptionBySecretKeyFailed,

--- a/src/genesis.rs
+++ b/src/genesis.rs
@@ -1,4 +1,4 @@
-use crate::{Amount, BlsHelper, KeyImage, Owner, OwnerOnce};
+use crate::{Amount, KeyImage, Owner, OwnerOnce};
 use blst_ringct::mlsag::{MlsagMaterial, TrueInput};
 use blst_ringct::ringct::RingCtMaterial;
 use blst_ringct::{Output, RevealedCommitment};
@@ -52,13 +52,13 @@ impl Default for GenesisMaterial {
         let output_sk_once = output_sk.derive_child(&output_owner_once.derivation_index);
 
         // build our TrueInput
-        let true_input = TrueInput {
-            secret_key: BlsHelper::blsttc_to_blstrs_secret_key(input_sk),
-            revealed_commitment: RevealedCommitment {
+        let true_input = TrueInput::new(
+            input_sk,
+            RevealedCommitment {
                 value: Self::GENESIS_AMOUNT,
                 blinding: 1776.into(), // freedom baby!
             },
-        };
+        );
 
         // make things a bit easier for our callers.
         let input_key_image: KeyImage = true_input.key_image().to_affine().into();
@@ -76,10 +76,10 @@ impl Default for GenesisMaterial {
         // onward to RingCtMaterial
         let ringct_material = RingCtMaterial {
             inputs: vec![mlsag_material],
-            outputs: vec![Output {
-                public_key: BlsHelper::blsttc_to_blstrs_public_key(&output_sk_once.public_key()),
-                amount: Self::GENESIS_AMOUNT,
-            }],
+            outputs: vec![Output::new(
+                output_sk_once.public_key(),
+                Self::GENESIS_AMOUNT,
+            )],
         };
 
         // Voila!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ mod verification;
 
 pub use crate::{
     amount_secrets::{Amount, AmountSecrets},
-    blst::{BlindingFactor, Commitment, KeyImage, PublicKeyBlstMappable},
+    blst::{BlindingFactor, Commitment, KeyImage},
     builder::mock::GenesisBuilderMock,
     builder::{DbcBuilder, Output, OutputOwnerMap, ReissueRequestBuilder, TransactionBuilder},
     dbc::Dbc,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,15 +23,12 @@ mod spentbook;
 mod verification;
 
 pub use crate::{
-    amount_secrets::AmountSecrets,
-    blst::{
-        BlindingFactor, BlsHelper, Commitment, KeyImage, PublicKeyBlst, PublicKeyBlstMappable,
-        SecretKeyBlst,
-    },
+    amount_secrets::{Amount, AmountSecrets},
+    blst::{BlindingFactor, Commitment, KeyImage, PublicKeyBlstMappable},
     builder::mock::GenesisBuilderMock,
     builder::{DbcBuilder, Output, OutputOwnerMap, ReissueRequestBuilder, TransactionBuilder},
     dbc::Dbc,
-    dbc_content::{Amount, DbcContent},
+    dbc_content::DbcContent,
     error::{Error, Result},
     genesis::GenesisMaterial,
     key_manager::{
@@ -81,7 +78,7 @@ impl AsRef<[u8]> for Hash {
 }
 
 #[cfg(feature = "dkg")]
-use rand::RngCore;
+use rand8::RngCore;
 
 #[cfg(feature = "dkg")]
 pub fn bls_dkg_id(rng: &mut impl RngCore) -> bls_dkg::outcome::Outcome {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ impl AsRef<[u8]> for Hash {
 }
 
 #[cfg(feature = "dkg")]
-use rand8::RngCore;
+use rand::RngCore;
 
 #[cfg(feature = "dkg")]
 pub fn bls_dkg_id(rng: &mut impl RngCore) -> bls_dkg::outcome::Outcome {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ pub use crate::{
     amount_secrets::{Amount, AmountSecrets},
     blst::{BlindingFactor, Commitment, KeyImage},
     builder::mock::GenesisBuilderMock,
-    builder::{DbcBuilder, Output, OutputOwnerMap, ReissueRequestBuilder, TransactionBuilder},
+    builder::{DbcBuilder, Output, OutputOwnerMap, TransactionBuilder},
     dbc::Dbc,
     dbc_content::DbcContent,
     error::{Error, Result},
@@ -35,7 +35,6 @@ pub use crate::{
         IndexedSignatureShare, KeyManager, PublicKey, PublicKeySet, Signature, SimpleKeyManager,
         SimpleSigner,
     },
-    mint::{MintNode, ReissueRequest, ReissueShare},
     owner::{DerivationIndex, Owner, OwnerOnce},
     spent_proof::{SpentProof, SpentProofContent, SpentProofShare},
     spentbook::SpentBookNodeMock,
@@ -64,7 +63,6 @@ impl From<[u8; 32]> for Hash {
 }
 
 // Display Hash value as hex in Debug output.  consolidates 36 lines to 3 for pretty output
-// and the hex value is the same as sn_dbc_mint display of DBC IDs.
 impl fmt::Debug for Hash {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("Hash").field(&hex::encode(self.0)).finish()

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -472,7 +472,7 @@ mod tests {
                     let idx = reissue_tx2
                         .mlsags
                         .iter()
-                        .position(|i| i.key_image == *key.as_ref())
+                        .position(|i| Into::<KeyImage>::into(i.key_image) == key)
                         .unwrap();
                     assert!(invalid_spent_proofs.contains(&idx));
                 }

--- a/src/owner.rs
+++ b/src/owner.rs
@@ -30,10 +30,10 @@ pub type DerivationIndex = [u8; 32];
 ///
 /// The base Owner public key is given out to other people
 /// in order to receive payments from them. It is never
-/// seen by the Mint or SpentBook.
+/// seen by the SpentBook.
 ///
 /// The one-time-use Owner public key is not normally given
-/// to 3rd parties. It is used by Mint and SpentBook exactly
+/// to 3rd parties. It is used by SpentBook exactly
 /// once, when spending the associated Dbc.
 ///
 /// See OwnerOnce which relates the two.

--- a/src/owner.rs
+++ b/src/owner.rs
@@ -6,15 +6,15 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::{BlsHelper, Error, PublicKey, PublicKeyBlst, Result, SecretKeyBlst};
+use crate::{Error, PublicKey, Result};
 use blsttc::{serde_impl::SerdeSecret, SecretKey};
 use std::fmt;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use rand::distributions::Standard;
-use rand::Rng;
+use rand8::distributions::Standard;
+use rand8::Rng;
 
 pub type DerivationIndex = [u8; 32];
 
@@ -98,18 +98,6 @@ impl Owner {
         }
     }
 
-    /// returns owner BLST PublicKey derived from owner base PublicKey
-    // note: can go away once blsttc integrated with blst_ringct.
-    pub fn public_key_blst(&self) -> PublicKeyBlst {
-        BlsHelper::blsttc_to_blstrs_public_key(&self.public_key())
-    }
-
-    /// returns owner BLST SecretKey derived from owner base SecretKey, if available.
-    // note: can go away once blsttc integrated with blst_ringct.
-    pub fn secret_key_blst(&self) -> Result<SecretKeyBlst> {
-        Ok(BlsHelper::blsttc_to_blstrs_secret_key(self.secret_key()?))
-    }
-
     /// derives new Owner from provided DerivationIndex
     pub fn derive(&self, i: &DerivationIndex) -> Self {
         match self {
@@ -135,7 +123,7 @@ impl Owner {
     }
 
     /// create Owner from a randomly generated SecretKey
-    pub fn from_random_secret_key(rng: &mut impl rand::RngCore) -> Self {
+    pub fn from_random_secret_key(rng: &mut impl rand8::RngCore) -> Self {
         let sk: SecretKey = rng.sample(Standard);
         Self::from(sk)
     }

--- a/src/owner.rs
+++ b/src/owner.rs
@@ -13,8 +13,8 @@ use std::fmt;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use rand8::distributions::Standard;
-use rand8::Rng;
+use rand::distributions::Standard;
+use rand::Rng;
 
 pub type DerivationIndex = [u8; 32];
 
@@ -123,7 +123,7 @@ impl Owner {
     }
 
     /// create Owner from a randomly generated SecretKey
-    pub fn from_random_secret_key(rng: &mut impl rand8::RngCore) -> Self {
+    pub fn from_random_secret_key(rng: &mut impl rand::RngCore) -> Self {
         let sk: SecretKey = rng.sample(Standard);
         Self::from(sk)
     }
@@ -158,7 +158,7 @@ impl OwnerOnce {
     }
 
     /// create OwnerOnce from a base Owner
-    pub fn from_owner_base(owner_base: Owner, rng: &mut impl rand8::RngCore) -> Self {
+    pub fn from_owner_base(owner_base: Owner, rng: &mut impl rand::RngCore) -> Self {
         Self {
             owner_base,
             derivation_index: Self::random_derivation_index(rng),
@@ -166,7 +166,7 @@ impl OwnerOnce {
     }
 
     // generates a random derivation index
-    pub(crate) fn random_derivation_index(rng: &mut impl rand8::RngCore) -> [u8; 32] {
+    pub(crate) fn random_derivation_index(rng: &mut impl rand::RngCore) -> [u8; 32] {
         let mut bytes = [0u8; 32];
         rng.fill_bytes(&mut bytes);
         bytes

--- a/src/spent_proof.rs
+++ b/src/spent_proof.rs
@@ -189,7 +189,7 @@ impl SpentProof {
                 &self.spentbook_pub_key,
                 &self.spentbook_sig,
             )
-            .map_err(|_| Error::InvalidSpentProofSignature(*self.key_image()))?;
+            .map_err(|e| Error::InvalidSpentProofSignature(*self.key_image(), e.to_string()))?;
         Ok(())
     }
 }

--- a/src/spentbook.rs
+++ b/src/spentbook.rs
@@ -12,7 +12,7 @@ use blstrs::group::Curve;
 use blsttc::PublicKey;
 use std::collections::{BTreeMap, HashMap};
 
-use rand8::prelude::IteratorRandom;
+use rand::prelude::IteratorRandom;
 
 use crate::{
     Commitment, GenesisMaterial, Hash, KeyImage, KeyManager, Result, SimpleKeyManager,
@@ -215,7 +215,7 @@ impl SpentBookNodeMock {
     pub fn random_decoys(
         &self,
         target_num: usize,
-        rng: &mut impl rand8::RngCore,
+        rng: &mut impl rand::RngCore,
     ) -> Vec<DecoyInput> {
         // Get a unique list of all OutputProof
         // note: Tx are duplicated in Spentbook. We use a BTreeMap

--- a/src/verification.rs
+++ b/src/verification.rs
@@ -6,20 +6,12 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::{Commitment, Error, Hash, KeyImage, KeyManager, PublicKey, Result, SpentProof};
+use crate::{Commitment, Error, Hash, KeyImage, KeyManager, Result, SpentProof};
 use blst_ringct::ringct::RingCtTransaction;
-use blsttc::Signature;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 
-// Here we are putting transaction verification logic that is common to both
-// MintNode::reissue() and Dbc::confirm_valid().
-//
-// It is best to have the verification logic in one place only!
-//
-// Note also that MintNode is server-side (mint) and Dbc is client-side (wallet).
-// In a future refactor, we intend to break the code into 3 modules:
-//   server, client, and common.  (or maybe mint, wallet, and common)
-// So TransactionValidator would go into common.
+// Here we are putting transaction verification logic that is beyond
+// what RingCtTransaction::verify() provides.
 //
 // Another way to do this would be to create a NewType wrapper for RingCtTransaction.
 // We can discuss if that is better or not.
@@ -27,90 +19,26 @@ use std::collections::{BTreeMap, BTreeSet};
 pub struct TransactionVerifier {}
 
 impl TransactionVerifier {
-    /// Verifies a transaction including mint signatures and spent proofs.
+    /// Verifies a transaction including spent proofs.
     ///
     /// This function relies/assumes that the caller (wallet/client) obtains
-    /// the mint's and spentbook's public keys (held by KeyManager) in a
+    /// the spentbook's public keys (held by KeyManager) in a
     /// trustless/verified way.  ie, the caller should not simply obtain keys
-    /// from a MintNode directly, but must somehow verify that the MintNode is
+    /// from a SpentBookNode directly, but must somehow verify that the node is
     /// a valid authority.
     ///
     /// note: for spent_proofs to verify, the verifier must have/know the
     ///       public key of each spentbook section that recorded a tx input as spent.
-    /// note: for mint_sigs to verify, the verifier must have/know the
-    ///       public key of the mint section that performed the reissue and signed tx.
     pub fn verify<K: KeyManager>(
         verifier: &K,
         transaction: &RingCtTransaction,
-        mint_sigs: &BTreeMap<KeyImage, (PublicKey, Signature)>,
-        spent_proofs: &BTreeSet<SpentProof>,
-    ) -> Result<(), Error> {
-        // Do quick checks first to reduce potential DOS vectors.
-
-        if mint_sigs.len() != transaction.mlsags.len() {
-            return Err(Error::MintSignatureInputMismatch);
-        }
-
-        // Verify that we received a mint pk/sig for each tx input.
-        for mlsag in transaction.mlsags.iter() {
-            if mint_sigs.get(&mlsag.key_image.into()).is_none() {
-                return Err(Error::MissingSignatureForInput);
-            }
-        }
-
-        // Obtain unique list of pk/sig, to avoid duplicate verify() calls when
-        // 2 or more inputs to our tx (a) were outputs of the same source tx (b).
-        let mint_sigs_unique: BTreeMap<Vec<u8>, (&PublicKey, &Signature)> = mint_sigs
-            .iter()
-            .map(|(_k, (pk, s))| (Self::pk_sig_bytes(pk, s), (pk, s)))
-            .collect();
-
-        // Verify that each unique mint signature is valid.
-        let tx_hash = Hash::from(transaction.hash());
-        for (_, (mint_key, mint_sig)) in mint_sigs_unique.iter() {
-            verifier
-                .verify(&tx_hash, mint_key, mint_sig)
-                .map_err(|e| Error::Signing(e.to_string()))?;
-        }
-
-        Self::verify_without_sigs_internal(verifier, transaction, tx_hash, spent_proofs)
-    }
-
-    fn pk_sig_bytes(pk: &PublicKey, sig: &Signature) -> Vec<u8> {
-        let mut bytes: Vec<u8> = Default::default();
-        bytes.extend(&pk.to_bytes());
-        bytes.extend(&sig.to_bytes());
-        bytes
-    }
-
-    /// Verifies a transaction including including spent proofs and excluding mint signatures.
-    ///
-    /// This function relies/assumes that the caller (wallet/client) obtains
-    /// spentbook's public keys (held by KeyManager) in a
-    /// trustless/verified way.  ie, the caller should not simply obtain keys
-    /// from a SpentBookNode directly, but must somehow verify that the
-    /// SpentBookNode is a valid authority.
-    ///
-    /// note: for spent_proofs to verify, the verifier must have/know the
-    ///       public key of each spentbook section that recorded a tx input as spent.
-    pub fn verify_without_sigs<K: KeyManager>(
-        verifier: &K,
-        transaction: &RingCtTransaction,
-        spent_proofs: &BTreeSet<SpentProof>,
-    ) -> Result<(), Error> {
-        let tx_hash = Hash::from(transaction.hash());
-        Self::verify_without_sigs_internal(verifier, transaction, tx_hash, spent_proofs)
-    }
-
-    fn verify_without_sigs_internal<K: KeyManager>(
-        verifier: &K,
-        transaction: &RingCtTransaction,
-        transaction_hash: Hash,
         spent_proofs: &BTreeSet<SpentProof>,
     ) -> Result<(), Error> {
         if spent_proofs.len() != transaction.mlsags.len() {
-            return Err(Error::SpentProofInputMismatch);
+            return Err(Error::SpentProofInputLenMismatch);
         }
+
+        let transaction_hash = Hash::from(transaction.hash());
 
         // Verify that each pubkey is unique in this transaction.
         let pubkey_unique: BTreeSet<KeyImage> = transaction
@@ -122,19 +50,23 @@ impl TransactionVerifier {
             return Err(Error::PublicKeyNotUniqueAcrossOutputs);
         }
 
-        // Verify that each input has a corresponding valid spent proof.
-        //
-        // note: for the proofs to verify, our key_manager must have/know
-        // the pubkey of the spentbook section that signed the proof.
-        // This is a responsibility of our caller, not this crate.
+        // Verify that each input has a corresponding spent proof.
         for spent_proof in spent_proofs.iter() {
             if !transaction
                 .mlsags
                 .iter()
                 .any(|m| Into::<KeyImage>::into(m.key_image) == *spent_proof.key_image())
             {
-                return Err(Error::SpentProofInputMismatch);
+                return Err(Error::SpentProofInputKeyImageMismatch);
             }
+        }
+
+        // Verify that each spent proof is valid
+        //
+        // note: for the proofs to verify, our key_manager must have/know
+        // the pubkey of the spentbook section that signed the proof.
+        // This is a responsibility of our caller, not this crate.
+        for spent_proof in spent_proofs.iter() {
             spent_proof.verify(transaction_hash, verifier)?;
         }
 

--- a/src/verification.rs
+++ b/src/verification.rs
@@ -131,7 +131,7 @@ impl TransactionVerifier {
             if !transaction
                 .mlsags
                 .iter()
-                .any(|m| m.key_image == *spent_proof.key_image().as_ref())
+                .any(|m| Into::<KeyImage>::into(m.key_image) == *spent_proof.key_image())
             {
                 return Err(Error::SpentProofInputMismatch);
             }
@@ -147,7 +147,7 @@ impl TransactionVerifier {
                 transaction
                     .mlsags
                     .iter()
-                    .position(|m| m.key_image == *s.key_image().as_ref())
+                    .position(|m| Into::<KeyImage>::into(m.key_image) == *s.key_image())
                     .map(|idx| (idx, s))
             })
             .collect();


### PR DESCRIPTION
This PR includes and obsoletes #154.  removes 827 LOC.   :+1: 

Alternatively, if #154 were merged as-is, I could rebase this branch to include only the mint removal.

-----

**integrate blsttc/blstrs**

highlights:

* we only use blsttc keys, no more Scalar/G1Affine.
* Amount is now defined in ringct and re-exported in sn_dbc.
* get rid of rand7, now rand8 everywhere
* use ringct::Output::new() and TrueInput::new()
* gets rid of BlsHelper, SecretKeyBlst, PublicKeyBlst
* TxBuilder methods to add output by Amount+OwnerOnce, simplifying tx creation.

lowlights:

* depends on lots of forks/branches in various repos and they all need to be merged/published.

------

remove mint::*

feat: remove mint nodes and related data structures

We realized that mint nodes no longer serve a useful purpose
as the spentbook nodes now both verify and sign the transaction.

By removing the mint nodes:
1. The client has less work to do.
2. Safe network elder nodes need only have a single role and do less work.
3. we remove a bunch of code from sn_dbc, making remaining code easier to learn/audit/maintain.
4. the system becomes more flexible as a spentbook can be anything that can generate a SpentProof.

* bench TransactionVerifier::verify() instead of MintNode::reissue()
* remove mint::* from mint-repl
* make TransactionBuilder::build() return only a DbcBuilder
* remove ReissueRequestBuilder
* modify DbcBuilder to build using SpentProofs
* add DbcBuilder::spent_proofs()
* remove all 'mint', 'Mint' from code/comments.
* remove mint sigs from Dbc
* fuzz spent proofs in prop_dbc_verification()
* remove obsolete/unused error variants
* remove all lib code from mint.rs.  (tests remain there for now)
* add KeyManager error as string to Error:InvalidSpentProofSignature
* remove mint sig verification from TransactionVerifier::verify()