### PR TITLE
Decouple deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,15 +15,15 @@ ringct-serde = [ "blst_ringct/serde" ]
 
 [dependencies]
 thiserror = "1.0.24"
-quickcheck_macros = "1"
-quickcheck = "1.0.3"
-blsttc = {git = "https://github.com/dan-da/blsttc", branch = "reexport_pr"}
-blst_ringct = {git = "https://github.com/dan-da/blst-ringct", branch = "fix_deps_pr"}
+blsttc = "5.1.2"
+blst_ringct = {git = "https://github.com/maidsafe/blst-ringct"}
 hex = "0.4.3"
 tiny-keccak = {version = "2.0.0", features = [ "sha3" ]}
 serde = {version = "1.0.133", features = [ "derive", "rc" ], optional = true}
 
 [dev-dependencies]
+quickcheck_macros = "1"
+quickcheck = "1.0.3"
 anyhow = "1.0.40"
 rustyline = "8.0.0"
 bincode = "1.3.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,58 +10,21 @@ authors = [ "MaidSafe Developers <dev@maidsafe.net>" ]
 edition = "2018"
 
 [features]
-dkg = [ "bls_dkg" ]
 serdes = [ "serde", "ringct-serde" ]
 ringct-serde = [ "blst_ringct/serde" ]
 
 [dependencies]
 thiserror = "1.0.24"
 quickcheck_macros = "1"
-rand = "0.8.0"
+quickcheck = "1.0.3"
+blsttc = {git = "https://github.com/dan-da/blsttc", branch = "reexport_pr"}
+blst_ringct = {git = "https://github.com/dan-da/blst-ringct", branch = "fix_deps_pr"}
 hex = "0.4.3"
-rand_core = "0.6.3"
-
-  [dependencies.blsttc]
-  git = "https://github.com/dan-da/blsttc"
-  branch = "sn_dbc_integration"
-
-  [dependencies.xor_name]
-  git = "https://github.com/iancoleman/xor_name"
-  branch = "remove_osrng"
-
-  [dependencies.quickcheck]
-  git = "https://github.com/davidrusu/quickcheck.git"
-  branch = "only-build-debug-reprs-on-failure"
-
-  [dependencies.blst_ringct]
-  git = "https://github.com/maidsafe/blst-ringct"
-
-  [dependencies.blstrs]
-  git = "https://github.com/davidrusu/blstrs.git"
-  branch = "bulletproofs-fixes"
-
-  [dependencies.bulletproofs]
-  git = "https://github.com/davidrusu/blst-bulletproofs.git"
-  branch = "bls12-381-curve"
-
-  [dependencies.bls_dkg]
-  git = "https://github.com/dan-da/bls_dkg.git"
-  branch = "sn_dbc_integration"
-  version = "~0.9.1"
-  optional = true
-
-  [dependencies.tiny-keccak]
-  version = "2.0.0"
-  features = [ "sha3" ]
-
-  [dependencies.serde]
-  version = "1.0.133"
-  features = [ "derive", "rc" ]
-  optional = true
+tiny-keccak = {version = "2.0.0", features = [ "sha3" ]}
+serde = {version = "1.0.133", features = [ "derive", "rc" ], optional = true}
 
 [dev-dependencies]
 anyhow = "1.0.40"
-rand = "0.8.0"
 rustyline = "8.0.0"
 bincode = "1.3.3"
 criterion = "0.3.5"
@@ -70,9 +33,9 @@ criterion = "0.3.5"
   version = "0.7.0"
   features = [ "flamegraph" ]
 
-  [dev-dependencies.sn_dbc]
-  path = "."
-  features = [ "dkg", "serdes" ]
+[dev-dependencies.sn_dbc]
+path = "."
+features = [ "serdes" ]
 
 [target."cfg(unix)".dev-dependencies]
 termios = "0.3.3"
@@ -80,7 +43,6 @@ termios = "0.3.3"
 [[bench]]
 name = "reissue"
 harness = false
-required-features = [ "dkg" ]
 
 [[example]]
 name = "mint-repl"

--- a/benches/reissue.rs
+++ b/benches/reissue.rs
@@ -9,20 +9,20 @@
 #![allow(clippy::from_iter_instead_of_collect)]
 
 use sn_dbc::{
-    Amount, Dbc, GenesisBuilderMock, Owner, OwnerOnce, Result, SpentBookNodeMock,
+    rng, Amount, Dbc, GenesisBuilderMock, Owner, OwnerOnce, Result, SpentBookNodeMock,
     TransactionVerifier,
 };
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use rand::SeedableRng as SeedableRng8;
 
 const N_OUTPUTS: u32 = 100;
 
 fn bench_reissue_1_to_100(c: &mut Criterion) {
-    let mut rng8 = rand::rngs::StdRng::from_seed([0u8; 32]);
+    let mut rng_ct = rng::ringct::from_seed([0u8; 32]);
+    let mut rng_ttc = rng::blsttc::from_seed([1u8; 32]);
 
     let (mut spentbook, starting_dbc) =
-        generate_dbc_of_value(N_OUTPUTS as Amount, &mut rng8).unwrap();
+        generate_dbc_of_value(N_OUTPUTS as Amount, &mut rng_ct, &mut rng_ttc).unwrap();
 
     let mut dbc_builder = sn_dbc::TransactionBuilder::default()
         .add_input_by_secrets(
@@ -33,14 +33,16 @@ fn bench_reissue_1_to_100(c: &mut Criterion) {
                 .unwrap(),
             starting_dbc.amount_secrets_bearer().unwrap(),
             vec![], // never any decoys for genesis
-            &mut rng8,
+            &mut rng_ct,
         )
         .add_outputs_by_amount((0..N_OUTPUTS).into_iter().map(|_| {
-            let owner_once =
-                OwnerOnce::from_owner_base(Owner::from_random_secret_key(&mut rng8), &mut rng8);
+            let owner_once = OwnerOnce::from_owner_base(
+                Owner::from_random_secret_key(&mut rng_ttc),
+                &mut rng_ttc,
+            );
             (1, owner_once)
         }))
-        .build(&mut rng8)
+        .build(&mut rng_ct)
         .unwrap();
 
     for (key_image, tx) in dbc_builder.inputs() {
@@ -51,25 +53,29 @@ fn bench_reissue_1_to_100(c: &mut Criterion) {
     let spent_proofs = dbc_builder.spent_proofs().unwrap();
     let tx = &dbc_builder.transaction;
 
-    let guard = pprof::ProfilerGuard::new(100).unwrap();
     c.bench_function(&format!("reissue split 1 to {}", N_OUTPUTS), |b| {
+        let guard = pprof::ProfilerGuard::new(100).unwrap();
+
         b.iter(|| {
             TransactionVerifier::verify(&spentbook.key_manager, black_box(tx), &spent_proofs)
                 .unwrap();
         });
+
+        if let Ok(report) = guard.report().build() {
+            let file =
+                std::fs::File::create(&format!("reissue_split_1_to_{}.svg", N_OUTPUTS)).unwrap();
+            report.flamegraph(file).unwrap();
+        };
     });
-    if let Ok(report) = guard.report().build() {
-        let file = std::fs::File::create(&format!("reissue_split_1_to_{}.svg", N_OUTPUTS)).unwrap();
-        report.flamegraph(file).unwrap();
-    };
 }
 
 fn bench_reissue_100_to_1(c: &mut Criterion) {
-    let mut rng8 = rand::rngs::StdRng::from_seed([0u8; 32]);
+    let mut rng_ct = rng::ringct::from_seed([0u8; 32]);
+    let mut rng_ttc = rng::ringct::from_seed([1u8; 32]);
     let num_decoys = 0;
 
     let (mut spentbook_node, starting_dbc) =
-        generate_dbc_of_value(N_OUTPUTS as Amount, &mut rng8).unwrap();
+        generate_dbc_of_value(N_OUTPUTS as Amount, &mut rng_ct, &mut rng_ttc).unwrap();
 
     let mut dbc_builder = sn_dbc::TransactionBuilder::default()
         .add_input_by_secrets(
@@ -80,14 +86,16 @@ fn bench_reissue_100_to_1(c: &mut Criterion) {
                 .unwrap(),
             starting_dbc.amount_secrets_bearer().unwrap(),
             vec![], // never any decoy inputs for genesis
-            &mut rng8,
+            &mut rng_ct,
         )
         .add_outputs_by_amount((0..N_OUTPUTS).into_iter().map(|_| {
-            let owner_once =
-                OwnerOnce::from_owner_base(Owner::from_random_secret_key(&mut rng8), &mut rng8);
+            let owner_once = OwnerOnce::from_owner_base(
+                Owner::from_random_secret_key(&mut rng_ttc),
+                &mut rng_ttc,
+            );
             (1, owner_once)
         }))
-        .build(&mut rng8)
+        .build(&mut rng_ct)
         .unwrap();
 
     for (key_image, tx) in dbc_builder.inputs() {
@@ -97,7 +105,7 @@ fn bench_reissue_100_to_1(c: &mut Criterion) {
     let dbcs = dbc_builder.build(&spentbook_node.key_manager).unwrap();
 
     let output_owner_once =
-        OwnerOnce::from_owner_base(Owner::from_random_secret_key(&mut rng8), &mut rng8);
+        OwnerOnce::from_owner_base(Owner::from_random_secret_key(&mut rng_ttc), &mut rng_ttc);
 
     let mut merge_dbc_builder = sn_dbc::TransactionBuilder::default()
         .add_inputs_by_secrets(
@@ -106,14 +114,14 @@ fn bench_reissue_100_to_1(c: &mut Criterion) {
                     (
                         owner_once.as_owner().secret_key().unwrap(),
                         amount_secrets,
-                        spentbook_node.random_decoys(num_decoys, &mut rng8),
+                        spentbook_node.random_decoys(num_decoys, &mut rng_ct),
                     )
                 })
                 .collect(),
-            &mut rng8,
+            &mut rng_ct,
         )
         .add_output_by_amount(N_OUTPUTS as Amount, output_owner_once)
-        .build(&mut rng8)
+        .build(&mut rng_ct)
         .unwrap();
 
     for (key_image, tx) in merge_dbc_builder.inputs() {
@@ -124,25 +132,29 @@ fn bench_reissue_100_to_1(c: &mut Criterion) {
     let spent_proofs = merge_dbc_builder.spent_proofs().unwrap();
     let tx = &merge_dbc_builder.transaction;
 
-    let guard = pprof::ProfilerGuard::new(100).unwrap();
     c.bench_function(&format!("reissue merge {} to 1", N_OUTPUTS), |b| {
+        let guard = pprof::ProfilerGuard::new(100).unwrap();
+
         b.iter(|| {
             TransactionVerifier::verify(&spentbook_node.key_manager, black_box(tx), &spent_proofs)
                 .unwrap();
         });
+
+        if let Ok(report) = guard.report().build() {
+            let file =
+                std::fs::File::create(&format!("reissue_merge_{}_to_1.svg", N_OUTPUTS)).unwrap();
+            report.flamegraph(file).unwrap();
+        };
     });
-    if let Ok(report) = guard.report().build() {
-        let file = std::fs::File::create(&format!("reissue_merge_{}_to_1.svg", N_OUTPUTS)).unwrap();
-        report.flamegraph(file).unwrap();
-    };
 }
 
 fn generate_dbc_of_value(
     amount: Amount,
-    rng8: &mut (impl rand::RngCore + rand_core::CryptoRng),
+    rng_ct: &mut (impl rng::ringct::rand::RngCore + rng::ringct::rand::CryptoRng),
+    rng_ttc: &mut (impl rng::blsttc::rand::RngCore + rng::blsttc::rand::CryptoRng),
 ) -> Result<(SpentBookNodeMock, Dbc)> {
     let (mut spentbook_node, genesis_dbc, _genesis_material, _amount_secrets) =
-        GenesisBuilderMock::init_genesis_single(rng8)?;
+        GenesisBuilderMock::init_genesis_single(rng_ct)?;
 
     let output_amounts = vec![amount, sn_dbc::GenesisMaterial::GENESIS_AMOUNT - amount];
 
@@ -151,13 +163,14 @@ fn generate_dbc_of_value(
             genesis_dbc.owner_once_bearer()?.secret_key()?,
             genesis_dbc.amount_secrets_bearer()?,
             vec![], // never any decoys for genesis
-            rng8,
+            rng_ct,
         )
         .add_outputs_by_amount(output_amounts.into_iter().map(|amount| {
-            let owner_once = OwnerOnce::from_owner_base(Owner::from_random_secret_key(rng8), rng8);
+            let owner_once =
+                OwnerOnce::from_owner_base(Owner::from_random_secret_key(rng_ttc), rng_ttc);
             (amount, owner_once)
         }))
-        .build(rng8)?;
+        .build(rng_ct)?;
 
     for (key_image, tx) in dbc_builder.inputs() {
         let spent_proof_share = spentbook_node.log_spent(key_image, tx)?;

--- a/examples/mint-repl/mint-repl.rs
+++ b/examples/mint-repl/mint-repl.rs
@@ -16,11 +16,11 @@ use rustyline::{config::Configurer, error::ReadlineError, Editor};
 use serde::{Deserialize, Serialize};
 
 use sn_dbc::{
-    blst_ringct::rand::seq::IteratorRandom,
     blsttc::{
         poly::Poly, serde_impl::SerdeSecret, PublicKey, PublicKeySet, SecretKey, SecretKeySet,
         SecretKeyShare,
     },
+    rand::{seq::IteratorRandom, Rng},
     rng, Amount, Dbc, DbcBuilder, GenesisBuilderMock, OutputOwnerMap, Owner, OwnerOnce,
     RevealedCommitment, RingCtMaterial, RingCtTransaction, SpentBookNodeMock, TransactionBuilder,
 };
@@ -178,7 +178,7 @@ fn mk_new_random_mint(threshold: usize) -> Result<MintInfo> {
 
 /// creates a new mint from an existing SecretKeySet that was seeded by poly.
 fn mk_new_mint(sks: SecretKeySet, poly: Poly) -> Result<MintInfo> {
-    let mut rng = rng::ringct::from_seed([0u8; 32]);
+    let mut rng = rng::from_seed([0u8; 32]);
 
     let num_spentbook_nodes = sks.threshold() + 1;
 
@@ -587,12 +587,12 @@ fn prepare_tx(mintinfo: &MintInfo) -> Result<DbcBuilder> {
 
         let decoy_inputs = mintinfo
             .spentbook()?
-            .random_decoys(STD_DECOYS, &mut rng::ringct::thread_rng());
+            .random_decoys(STD_DECOYS, &mut rng::thread_rng());
         tx_builder = tx_builder.add_input_dbc(
             &dbc,
             &base_secret_key,
             decoy_inputs,
-            &mut rng::ringct::thread_rng(),
+            &mut rng::thread_rng(),
         )?;
     }
 
@@ -650,7 +650,7 @@ fn prepare_tx(mintinfo: &MintInfo) -> Result<DbcBuilder> {
                             Some(Owner::from(public_key))
                         }
                     },
-                    "r" => Some(Owner::from_random_secret_key(&mut rng::blsttc::thread_rng())),
+                    "r" => Some(Owner::from_random_secret_key(&mut rng::thread_rng())),
                     "c" => return Err(anyhow!("Cancelled")),
                     _ => None,
                 };
@@ -659,7 +659,7 @@ fn prepare_tx(mintinfo: &MintInfo) -> Result<DbcBuilder> {
             }
         };
 
-        let owner_once = OwnerOnce::from_owner_base(owner_base, &mut rng::blsttc::thread_rng());
+        let owner_once = OwnerOnce::from_owner_base(owner_base, &mut rng::thread_rng());
 
         tx_builder = tx_builder.add_output_by_amount(amount, owner_once);
 
@@ -668,7 +668,7 @@ fn prepare_tx(mintinfo: &MintInfo) -> Result<DbcBuilder> {
 
     println!("\n\nPreparing RingCtTransaction...\n\n");
 
-    let dbc_builder = tx_builder.build(&mut rng::ringct::thread_rng())?;
+    let dbc_builder = tx_builder.build(&mut rng::thread_rng())?;
 
     Ok(dbc_builder)
 }
@@ -698,24 +698,21 @@ impl From<Vec<Dbc>> for ReissueAuto {
 }
 
 fn reissue_auto_cli(mintinfo: &mut MintInfo) -> Result<()> {
-    use sn_dbc::blst_ringct::rand::Rng;
-
-    let mut rng_ct = rng::ringct::thread_rng();
-    let mut rng_ttc = rng::blsttc::thread_rng();
+    let mut rng = rng::thread_rng();
 
     let num_reissues: usize =
         readline_prompt_nl_default("\nHow many reissues to perform [10]: ", "10")?.parse()?;
 
     for _i in 1..=num_reissues {
         let max_inputs = std::cmp::min(mintinfo.reissue_auto.unspent_dbcs.len(), 10);
-        let num_inputs = rng_ct.gen_range(1..max_inputs + 1);
+        let num_inputs = rng.gen_range(1..max_inputs + 1);
 
         // subset of unspent_dbcs become the inputs for next reissue.
         let input_dbcs: Vec<Dbc> = mintinfo
             .reissue_auto
             .unspent_dbcs
             .iter()
-            .choose_multiple(&mut rng_ct, num_inputs)
+            .choose_multiple(&mut rng, num_inputs)
             .iter()
             .map(|(_, d)| (*d).clone())
             .collect();
@@ -724,11 +721,9 @@ fn reissue_auto_cli(mintinfo: &mut MintInfo) -> Result<()> {
 
         for dbc in input_dbcs.iter() {
             let base_sk = dbc.owner_base().secret_key()?;
-            let decoy_inputs = mintinfo
-                .spentbook()?
-                .random_decoys(STD_DECOYS, &mut rng_ttc);
+            let decoy_inputs = mintinfo.spentbook()?.random_decoys(STD_DECOYS, &mut rng);
 
-            tx_builder = tx_builder.add_input_dbc(dbc, &base_sk, decoy_inputs, &mut rng_ct)?;
+            tx_builder = tx_builder.add_input_dbc(dbc, &base_sk, decoy_inputs, &mut rng)?;
         }
 
         let inputs_sum = tx_builder.inputs_amount_sum();
@@ -737,17 +732,15 @@ fn reissue_auto_cli(mintinfo: &mut MintInfo) -> Result<()> {
             // randomize output amount
             let diff = inputs_sum - tx_builder.outputs_amount_sum();
             let range_max = if diff == Amount::MAX { diff } else { diff + 1 };
-            let amount = rng_ct.gen_range(0..range_max);
+            let amount = rng.gen_range(0..range_max);
 
-            let owner_once = OwnerOnce::from_owner_base(
-                Owner::from_random_secret_key(&mut rng_ttc),
-                &mut rng_ttc,
-            );
+            let owner_once =
+                OwnerOnce::from_owner_base(Owner::from_random_secret_key(&mut rng), &mut rng);
 
             tx_builder = tx_builder.add_output_by_amount(amount, owner_once);
         }
 
-        let mut dbc_builder = tx_builder.build(&mut rng_ct)?;
+        let mut dbc_builder = tx_builder.build(&mut rng)?;
 
         for (key_image, tx) in dbc_builder.inputs() {
             for spentbook_node in mintinfo.spentbook_nodes.iter_mut() {
@@ -801,8 +794,7 @@ fn reissue(mintinfo: &mut MintInfo, dbc_builder: DbcBuilder) -> Result<()> {
 
 /// Makes a new random SecretKeySet
 fn mk_secret_key_set(threshold: usize) -> Result<(Poly, SecretKeySet)> {
-    let poly =
-        Poly::try_random(threshold, &mut rng::blsttc::thread_rng()).map_err(|e| anyhow!(e))?;
+    let poly = Poly::try_random(threshold, &mut rng::thread_rng()).map_err(|e| anyhow!(e))?;
     Ok((poly.clone(), SecretKeySet::from(poly)))
 }
 

--- a/src/amount_secrets.rs
+++ b/src/amount_secrets.rs
@@ -7,12 +7,11 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::{BlindingFactor, Error};
-use blst_ringct::RevealedCommitment;
+use blst_ringct::{rand::RngCore, RevealedCommitment};
 use blsttc::{
     Ciphertext, DecryptionShare, IntoFr, PublicKey, PublicKeySet, SecretKey, SecretKeySet,
     SecretKeyShare,
 };
-use rand_core::RngCore;
 use std::collections::BTreeMap;
 use std::convert::TryFrom;
 

--- a/src/amount_secrets.rs
+++ b/src/amount_secrets.rs
@@ -6,8 +6,9 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use crate::rand::RngCore;
 use crate::{BlindingFactor, Error};
-use blst_ringct::{rand::RngCore, RevealedCommitment};
+use blst_ringct::RevealedCommitment;
 use blsttc::{
     Ciphertext, DecryptionShare, IntoFr, PublicKey, PublicKeySet, SecretKey, SecretKeySet,
     SecretKeyShare,

--- a/src/blst.rs
+++ b/src/blst.rs
@@ -18,10 +18,10 @@
 //! crates consistent.
 
 /// a Commitment
-pub type Commitment = blstrs::G1Affine;
+pub type Commitment = blst_ringct::blstrs::G1Affine;
 
 /// a BlindingFactor
-pub type BlindingFactor = blstrs::Scalar;
+pub type BlindingFactor = blst_ringct::blstrs::Scalar;
 
 /// A KeyImage can be thought of as a specific type
 /// of public key. blsttc::PublicKey is a newtype

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -6,12 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use blst_ringct::{
-    bulletproofs::PedersenGens,
-    group::Curve,
-    rand::{CryptoRng, RngCore},
-    ringct::Amount,
-};
+use blst_ringct::{bulletproofs::PedersenGens, group::Curve, ringct::Amount};
 pub use blst_ringct::{
     ringct::RingCtTransaction, DecoyInput, MlsagMaterial, Output, RevealedCommitment,
     RingCtMaterial, TrueInput,
@@ -20,6 +15,7 @@ use blsttc::{PublicKey, SecretKey};
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 use crate::{
+    rand::{CryptoRng, RngCore},
     AmountSecrets, Commitment, Dbc, DbcContent, Error, Hash, IndexedSignatureShare, KeyImage,
     KeyManager, OwnerOnce, Result, SpentProof, SpentProofContent, SpentProofShare,
     TransactionVerifier,
@@ -424,7 +420,7 @@ pub mod mock {
         pub fn gen_spentbook_nodes(
             mut self,
             num_nodes: usize,
-            rng: &mut impl blsttc::rand::RngCore,
+            rng: &mut impl crate::rand::RngCore,
         ) -> Result<Self> {
             let sks = SecretKeySet::try_random(num_nodes - 1, rng)?;
             self = self.gen_spentbook_nodes_with_sks(num_nodes, &sks);

--- a/src/dbc.rs
+++ b/src/dbc.rs
@@ -262,6 +262,7 @@ pub(crate) mod tests {
 
     use crate::tests::{NonZeroTinyInt, TinyInt};
     use crate::{
+        rand::{CryptoRng, RngCore},
         Amount, AmountSecrets, DbcBuilder, GenesisBuilderMock, Hash, Owner, OwnerOnce,
         SimpleKeyManager, SimpleSigner, SpentBookNodeMock, SpentProofContent,
     };
@@ -289,16 +290,16 @@ pub(crate) mod tests {
         n_ways: u8,
         output_owners: Vec<OwnerOnce>,
         spentbook_node: &mut SpentBookNodeMock,
-        rng_ct: &mut (impl blst_ringct::rand::RngCore + blst_ringct::rand::CryptoRng),
+        rng: &mut (impl RngCore + CryptoRng),
     ) -> Result<DbcBuilder> {
         let amount = amount_secrets.amount();
 
-        let decoy_inputs = spentbook_node.random_decoys(STD_NUM_DECOYS, rng_ct);
+        let decoy_inputs = spentbook_node.random_decoys(STD_NUM_DECOYS, rng);
 
         let mut dbc_builder = crate::TransactionBuilder::default()
-            .add_input_by_secrets(dbc_owner, amount_secrets, decoy_inputs, rng_ct)
+            .add_input_by_secrets(dbc_owner, amount_secrets, decoy_inputs, rng)
             .add_outputs_by_amount(divide(amount, n_ways).zip(output_owners.into_iter()))
-            .build(rng_ct)?;
+            .build(rng)?;
 
         for (key_image, tx) in dbc_builder.inputs() {
             dbc_builder =
@@ -310,12 +311,11 @@ pub(crate) mod tests {
 
     #[test]
     fn test_dbc_without_inputs_fails_verification() -> Result<(), Error> {
-        let mut rng_ct = crate::rng::blsttc::from_seed([0u8; 32]);
-        let mut rng_ttc = crate::rng::blsttc::from_seed([1u8; 32]);
+        let mut rng = crate::rng::from_seed([0u8; 32]);
         let amount = 100;
 
         let owner_once =
-            OwnerOnce::from_owner_base(Owner::from_random_secret_key(&mut rng_ttc), &mut rng_ttc);
+            OwnerOnce::from_owner_base(Owner::from_random_secret_key(&mut rng), &mut rng);
 
         let ringct_material = RingCtMaterial {
             inputs: vec![],
@@ -323,7 +323,7 @@ pub(crate) mod tests {
         };
 
         let (transaction, revealed_commitments) = ringct_material
-            .sign(&mut rng_ct)
+            .sign(&mut rng)
             .expect("Failed to sign transaction");
 
         assert_eq!(revealed_commitments.len(), 1);
@@ -340,7 +340,7 @@ pub(crate) mod tests {
             spent_proofs: Default::default(),
         };
 
-        let id = crate::bls_dkg_id(&mut rng_ttc);
+        let id = crate::bls_dkg_id(&mut rng);
         let key_manager = SimpleKeyManager::from(SimpleSigner::from(id));
 
         assert!(matches!(
@@ -363,8 +363,7 @@ pub(crate) mod tests {
         n_extra_input_sigs: TinyInt,  // # of sigs for inputs not part of the transaction
         extra_output_amount: TinyInt, // Artifically increase output dbc value
     ) -> Result<(), Error> {
-        let mut rng_ct = crate::rng::ringct::from_seed([0u8; 32]);
-        let mut rng_ttc = crate::rng::ringct::from_seed([1u8; 32]);
+        let mut rng = crate::rng::from_seed([0u8; 32]);
 
         let amount = 100;
 
@@ -376,15 +375,10 @@ pub(crate) mod tests {
         // we add extra_output_amount to amount, which would otherwise
         // cause an integer overflow.
         let (mut spentbook_node, _genesis_dbc, starting_dbc, _change_dbc) =
-            generate_dbc_of_value(amount, &mut rng_ct, &mut rng_ttc)?;
+            generate_dbc_of_value(amount, &mut rng)?;
 
         let input_owners: Vec<OwnerOnce> = (0..n_inputs.coerce())
-            .map(|_| {
-                OwnerOnce::from_owner_base(
-                    Owner::from_random_secret_key(&mut rng_ttc),
-                    &mut rng_ttc,
-                )
-            })
+            .map(|_| OwnerOnce::from_owner_base(Owner::from_random_secret_key(&mut rng), &mut rng))
             .collect();
 
         let dbc_builder = prepare_even_split(
@@ -393,7 +387,7 @@ pub(crate) mod tests {
             n_inputs.coerce(),
             input_owners,
             &mut spentbook_node,
-            &mut rng_ct,
+            &mut rng,
         )?;
 
         let output_dbcs = dbc_builder.build(&spentbook_node.key_manager)?;
@@ -415,18 +409,18 @@ pub(crate) mod tests {
                 (
                     dbc,
                     owner_once.owner_base().secret_key().unwrap(),
-                    spentbook_node.random_decoys(STD_NUM_DECOYS, &mut rng_ct),
+                    spentbook_node.random_decoys(STD_NUM_DECOYS, &mut rng),
                 )
             })
             .collect();
 
         let owner_once =
-            OwnerOnce::from_owner_base(Owner::from_random_secret_key(&mut rng_ttc), &mut rng_ttc);
+            OwnerOnce::from_owner_base(Owner::from_random_secret_key(&mut rng), &mut rng);
 
         let mut dbc_builder = crate::TransactionBuilder::default()
-            .add_inputs_dbc(inputs, &mut rng_ct)?
+            .add_inputs_dbc(inputs, &mut rng)?
             .add_output_by_amount(amount, owner_once.clone())
-            .build(&mut rng_ct)?;
+            .build(&mut rng)?;
 
         for (key_image, tx) in dbc_builder.inputs() {
             dbc_builder =
@@ -474,7 +468,7 @@ pub(crate) mod tests {
         // Invalid spentbook signatures BUT signing correct message
         for _ in 0..n_wrong_signer_sigs.coerce() {
             if let Some(spent_proof) = repeating_inputs.next() {
-                let id = crate::bls_dkg_id(&mut rng_ttc);
+                let id = crate::bls_dkg_id(&mut rng);
                 let key_manager = SimpleKeyManager::from(SimpleSigner::from(id));
                 let sig_share = key_manager.sign(&spent_proof.content.hash()).unwrap();
                 let sig = key_manager
@@ -514,12 +508,12 @@ pub(crate) mod tests {
             }
         }
 
-        use blsttc::rand::distributions::{Distribution, Standard};
+        use crate::rand::distributions::{Distribution, Standard};
 
         // Valid spentbook signatures for inputs not present in the transaction
         for _ in 0..n_extra_input_sigs.coerce() {
             if let Some(spent_proof) = repeating_inputs.next() {
-                let secret_key: SecretKey = Standard.sample(&mut rng_ttc);
+                let secret_key: SecretKey = Standard.sample(&mut rng);
 
                 let content = SpentProofContent {
                     key_image: secret_key.public_key(),
@@ -619,11 +613,10 @@ pub(crate) mod tests {
 
     pub(crate) fn generate_dbc_of_value(
         amount: Amount,
-        rng_ct: &mut (impl blst_ringct::rand::RngCore + blst_ringct::rand::CryptoRng),
-        rng_ttc: &mut (impl blsttc::rand::RngCore + blsttc::rand::CryptoRng),
+        rng: &mut (impl RngCore + CryptoRng),
     ) -> Result<(SpentBookNodeMock, Dbc, Dbc, Dbc)> {
         let (mut spentbook_node, genesis_dbc, _genesis_material, _amount_secrets) =
-            GenesisBuilderMock::init_genesis_single(rng_ct)?;
+            GenesisBuilderMock::init_genesis_single(rng)?;
 
         let output_amounts = vec![amount, sn_dbc::GenesisMaterial::GENESIS_AMOUNT - amount];
 
@@ -632,15 +625,15 @@ pub(crate) mod tests {
                 genesis_dbc.owner_once_bearer()?.secret_key()?,
                 genesis_dbc.amount_secrets_bearer()?,
                 vec![], // never any decoys for genesis
-                rng_ct,
+                rng,
             )
             .add_outputs_by_amount(output_amounts.into_iter().map(|amount| {
                 (
                     amount,
-                    OwnerOnce::from_owner_base(Owner::from_random_secret_key(rng_ttc), rng_ttc),
+                    OwnerOnce::from_owner_base(Owner::from_random_secret_key(rng), rng),
                 )
             }))
-            .build(rng_ct)?;
+            .build(rng)?;
 
         for (key_image, tx) in dbc_builder.inputs() {
             dbc_builder =

--- a/src/genesis.rs
+++ b/src/genesis.rs
@@ -1,9 +1,11 @@
 use crate::{Amount, KeyImage, Owner, OwnerOnce};
-use blst_ringct::mlsag::{MlsagMaterial, TrueInput};
-use blst_ringct::ringct::RingCtMaterial;
-use blst_ringct::{Output, RevealedCommitment};
-use blstrs::group::Curve;
-use blstrs::Scalar;
+use blst_ringct::{
+    blstrs::Scalar,
+    group::Curve,
+    mlsag::{MlsagMaterial, TrueInput},
+    ringct::RingCtMaterial,
+    {Output, RevealedCommitment},
+};
 use blsttc::IntoFr;
 
 /// represents all the inputs required to build the Genesis Dbc.

--- a/src/key_manager.rs
+++ b/src/key_manager.rs
@@ -66,12 +66,11 @@ pub struct SimpleSigner {
     secret_key_share: (u64, SerdeSecret<SecretKeyShare>),
 }
 
-#[cfg(feature = "dkg")]
-impl From<bls_dkg::outcome::Outcome> for SimpleSigner {
-    fn from(outcome: bls_dkg::outcome::Outcome) -> Self {
+impl From<(PublicKeySet, SecretKeyShare, usize)> for SimpleSigner {
+    fn from(outcome: (PublicKeySet, SecretKeyShare, usize)) -> Self {
         Self {
-            public_key_set: outcome.public_key_set,
-            secret_key_share: (outcome.index as u64, SerdeSecret(outcome.secret_key_share)),
+            public_key_set: outcome.0,
+            secret_key_share: (outcome.2 as u64, SerdeSecret(outcome.1)),
         }
     }
 }
@@ -83,7 +82,6 @@ impl SimpleSigner {
             secret_key_share: (secret_key_share.0, SerdeSecret(secret_key_share.1)),
         }
     }
-
     fn index(&self) -> u64 {
         self.secret_key_share.0
     }

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -24,10 +24,10 @@ mod tests {
 
     #[test]
     fn issue_genesis() -> Result<(), Error> {
-        let mut rng_ct = crate::rng::ringct::from_seed([0u8; 32]);
+        let mut rng = crate::rng::from_seed([0u8; 32]);
 
         let (spentbook_node, genesis_dbc, genesis, _amount_secrets) =
-            GenesisBuilderMock::init_genesis_single(&mut rng_ct)?;
+            GenesisBuilderMock::init_genesis_single(&mut rng)?;
 
         let verified = genesis_dbc.verify(
             &genesis.owner_once.owner_base().secret_key()?,
@@ -40,8 +40,7 @@ mod tests {
 
     #[quickcheck]
     fn prop_splitting_the_genesis_dbc(output_amounts: TinyVec<TinyInt>) -> Result<(), Error> {
-        let mut rng_ct = crate::rng::ringct::from_seed([0u8; 32]);
-        let mut rng_ttc = crate::rng::ringct::from_seed([1u8; 32]);
+        let mut rng = crate::rng::from_seed([0u8; 32]);
 
         let mut output_amounts =
             Vec::from_iter(output_amounts.into_iter().map(TinyInt::coerce::<Amount>));
@@ -52,15 +51,10 @@ mod tests {
         let output_amount = output_amounts.iter().sum();
 
         let (mut spentbook_node, genesis_dbc, _genesis, _amount_secrets) =
-            GenesisBuilderMock::init_genesis_single(&mut rng_ct)?;
+            GenesisBuilderMock::init_genesis_single(&mut rng)?;
 
         let owners: Vec<OwnerOnce> = (0..output_amounts.len())
-            .map(|_| {
-                OwnerOnce::from_owner_base(
-                    Owner::from_random_secret_key(&mut rng_ttc),
-                    &mut rng_ttc,
-                )
-            })
+            .map(|_| OwnerOnce::from_owner_base(Owner::from_random_secret_key(&mut rng), &mut rng))
             .collect();
 
         let mut dbc_builder = TransactionBuilder::default()
@@ -68,7 +62,7 @@ mod tests {
                 &genesis_dbc,
                 &genesis_dbc.owner_base().secret_key()?,
                 vec![], // genesis is only input, so no decoys.
-                &mut rng_ct,
+                &mut rng,
             )?
             .add_outputs_by_amount(
                 output_amounts
@@ -76,7 +70,7 @@ mod tests {
                     .enumerate()
                     .map(|(idx, a)| (*a, owners[idx].clone())),
             )
-            .build(&mut rng_ct)?;
+            .build(&mut rng)?;
 
         // We make this a closure to keep the spentbook loop readable.
         let check_error = |error: Error| -> Result<()> {
@@ -146,8 +140,7 @@ mod tests {
         // The number of decoy inputs
         num_decoy_inputs: TinyInt,
     ) -> Result<(), Error> {
-        let mut rng_ct = crate::rng::ringct::from_seed([0u8; 32]);
-        let mut rng_ttc = crate::rng::ringct::from_seed([0u8; 32]);
+        let mut rng = crate::rng::from_seed([0u8; 32]);
 
         let mut input_amounts =
             Vec::from_iter(input_amounts.into_iter().map(TinyInt::coerce::<Amount>));
@@ -170,23 +163,21 @@ mod tests {
         let num_decoy_inputs: usize = num_decoy_inputs.coerce::<usize>() % 2;
 
         let (mut spentbook_node, genesis_dbc, _genesis, _amount_secrets) =
-            GenesisBuilderMock::init_genesis_single(&mut rng_ct)?;
+            GenesisBuilderMock::init_genesis_single(&mut rng)?;
 
         let mut dbc_builder = TransactionBuilder::default()
             .add_input_dbc(
                 &genesis_dbc,
                 &genesis_dbc.owner_base().secret_key()?,
                 vec![], // genesis is only input, so no decoys.
-                &mut rng_ct,
+                &mut rng,
             )?
             .add_outputs_by_amount(input_amounts.iter().copied().map(|amount| {
-                let owner_once = OwnerOnce::from_owner_base(
-                    Owner::from_random_secret_key(&mut rng_ttc),
-                    &mut rng_ttc,
-                );
+                let owner_once =
+                    OwnerOnce::from_owner_base(Owner::from_random_secret_key(&mut rng), &mut rng);
                 (amount, owner_once)
             }))
-            .build(&mut rng_ct)?;
+            .build(&mut rng)?;
 
         // note: we make this a closure to keep the spentbook loop readable.
         let check_tx_error = |error: Error| -> Result<()> {
@@ -221,26 +212,21 @@ mod tests {
                 (
                     dbc,
                     owner_once.owner_base().secret_key().unwrap(),
-                    spentbook_node.random_decoys(num_decoy_inputs, &mut rng_ct),
+                    spentbook_node.random_decoys(num_decoy_inputs, &mut rng),
                 )
             })
             .collect();
 
         let owners: Vec<OwnerOnce> = (0..=output_amounts.len())
-            .map(|_| {
-                OwnerOnce::from_owner_base(
-                    Owner::from_random_secret_key(&mut rng_ttc),
-                    &mut rng_ttc,
-                )
-            })
+            .map(|_| OwnerOnce::from_owner_base(Owner::from_random_secret_key(&mut rng), &mut rng))
             .collect();
 
         let outputs = output_amounts.clone().into_iter().zip(owners);
 
         let mut dbc_builder = TransactionBuilder::default()
-            .add_inputs_dbc(inputs_dbcs.clone(), &mut rng_ct)?
+            .add_inputs_dbc(inputs_dbcs.clone(), &mut rng)?
             .add_outputs_by_amount(outputs.clone())
-            .build(&mut rng_ct)?;
+            .build(&mut rng)?;
 
         let dbc_output_amounts: Vec<Amount> = outputs.map(|(amt, _)| amt).collect();
         let output_total_amount: Amount = dbc_output_amounts.iter().sum();
@@ -319,7 +305,7 @@ mod tests {
                         spentbook_pks: spent_proof_share.spentbook_pks,
                         spentbook_sig_share: IndexedSignatureShare::new(
                             0,
-                            SecretKeySet::random(1, &mut rng_ttc)
+                            SecretKeySet::random(1, &mut rng)
                                 .secret_key_share(1)
                                 .sign(&[0u8; 32]),
                         ),
@@ -386,30 +372,29 @@ mod tests {
 
     #[test]
     fn test_inputs_are_verified() -> Result<(), Error> {
-        let mut rng_ct = crate::rng::ringct::from_seed([0u8; 32]);
-        let mut rng_ttc = crate::rng::ringct::from_seed([1u8; 32]);
+        let mut rng = crate::rng::from_seed([0u8; 32]);
 
         let (spentbook_node, _genesis_dbc, _genesis, _amount_secrets) =
-            GenesisBuilderMock::init_genesis_single(&mut rng_ct)?;
+            GenesisBuilderMock::init_genesis_single(&mut rng)?;
 
         let output1_owner =
-            OwnerOnce::from_owner_base(Owner::from_random_secret_key(&mut rng_ttc), &mut rng_ttc);
+            OwnerOnce::from_owner_base(Owner::from_random_secret_key(&mut rng), &mut rng);
 
         let dbc_builder = TransactionBuilder::default()
             .add_output_by_amount(100, output1_owner.clone())
-            .build(&mut rng_ct)?;
+            .build(&mut rng)?;
 
         let amount_secrets = AmountSecrets::from(dbc_builder.revealed_commitments[0]);
         let secret_key = output1_owner.as_owner().secret_key()?;
         let decoy_inputs = vec![]; // no decoys.
 
         let output2_owner =
-            OwnerOnce::from_owner_base(Owner::from_random_secret_key(&mut rng_ttc), &mut rng_ttc);
+            OwnerOnce::from_owner_base(Owner::from_random_secret_key(&mut rng), &mut rng);
 
         let fraud_dbc_builder = TransactionBuilder::default()
-            .add_input_by_secrets(secret_key, amount_secrets, decoy_inputs, &mut rng_ct)
+            .add_input_by_secrets(secret_key, amount_secrets, decoy_inputs, &mut rng)
             .add_output_by_amount(100, output2_owner)
-            .build(&mut rng_ct)?;
+            .build(&mut rng)?;
 
         let result = fraud_dbc_builder.build(&spentbook_node.key_manager);
 
@@ -456,13 +441,12 @@ mod tests {
         // ----------
         // 1. produce a standard genesis DBC (a) with value 1000
         // ----------
-        let mut rng_ct = crate::rng::ringct::from_seed([0u8; 32]);
-        let mut rng_ttc = crate::rng::ringct::from_seed([0u8; 32]);
+        let mut rng = crate::rng::from_seed([0u8; 32]);
 
         let output_amount = 1000;
 
         let (mut spentbook, genesis_dbc, starting_dbc, _change_dbc) =
-            crate::dbc::tests::generate_dbc_of_value(output_amount, &mut rng_ct, &mut rng_ttc)?;
+            crate::dbc::tests::generate_dbc_of_value(output_amount, &mut rng)?;
 
         // ----------
         // 2. spend genesis DBC (a) to Dbc (b)  with value 1000.
@@ -472,17 +456,17 @@ mod tests {
         // single new DBC of the same amount.
 
         let output_owner =
-            OwnerOnce::from_owner_base(Owner::from_random_secret_key(&mut rng_ttc), &mut rng_ttc);
+            OwnerOnce::from_owner_base(Owner::from_random_secret_key(&mut rng), &mut rng);
 
         let mut dbc_builder = TransactionBuilder::default()
             .add_input_dbc(
                 &starting_dbc,
                 &starting_dbc.owner_base().secret_key()?,
                 vec![], // genesis is only input, so no decoys.
-                &mut rng_ct,
+                &mut rng,
             )?
             .add_output_by_amount(output_amount, output_owner.clone())
-            .build(&mut rng_ct)?;
+            .build(&mut rng)?;
 
         for (key_image, tx) in dbc_builder.inputs() {
             dbc_builder =
@@ -554,17 +538,17 @@ mod tests {
         let decoy_inputs = vec![];
 
         let output_owner =
-            OwnerOnce::from_owner_base(Owner::from_random_secret_key(&mut rng_ttc), &mut rng_ttc);
+            OwnerOnce::from_owner_base(Owner::from_random_secret_key(&mut rng), &mut rng);
 
         let mut dbc_builder_fudged = crate::TransactionBuilder::default()
             .add_input_dbc(
                 &fudged_output_dbc,
                 &fudged_output_dbc.owner_base().secret_key()?,
                 decoy_inputs.clone(),
-                &mut rng_ct,
+                &mut rng,
             )?
             .add_output_by_amount(fudged_secrets.amount(), output_owner.clone())
-            .build(&mut rng_ct)?;
+            .build(&mut rng)?;
 
         // ----------
         // 6. Attempt to write this tx to the spentbook.
@@ -618,10 +602,10 @@ mod tests {
                 fudged_output_dbc.owner_once_bearer()?.secret_key()?,
                 true_secrets.clone(),
                 decoy_inputs,
-                &mut rng_ct,
+                &mut rng,
             )
             .add_output_by_amount(true_secrets.amount(), output_owner)
-            .build(&mut rng_ct)?;
+            .build(&mut rng)?;
 
         let dbc_builder_bad_proof = dbc_builder_true.clone();
         for (key_image, tx) in dbc_builder_bad_proof.inputs() {

--- a/src/owner.rs
+++ b/src/owner.rs
@@ -13,8 +13,7 @@ use std::fmt;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use rand::distributions::Standard;
-use rand::Rng;
+use blsttc::{rand::distributions::Standard, rand::Rng, rand::RngCore};
 
 pub type DerivationIndex = [u8; 32];
 
@@ -123,7 +122,7 @@ impl Owner {
     }
 
     /// create Owner from a randomly generated SecretKey
-    pub fn from_random_secret_key(rng: &mut impl rand::RngCore) -> Self {
+    pub fn from_random_secret_key(rng: &mut impl RngCore) -> Self {
         let sk: SecretKey = rng.sample(Standard);
         Self::from(sk)
     }
@@ -158,7 +157,7 @@ impl OwnerOnce {
     }
 
     /// create OwnerOnce from a base Owner
-    pub fn from_owner_base(owner_base: Owner, rng: &mut impl rand::RngCore) -> Self {
+    pub fn from_owner_base(owner_base: Owner, rng: &mut impl RngCore) -> Self {
         Self {
             owner_base,
             derivation_index: Self::random_derivation_index(rng),
@@ -166,7 +165,7 @@ impl OwnerOnce {
     }
 
     // generates a random derivation index
-    pub(crate) fn random_derivation_index(rng: &mut impl rand::RngCore) -> [u8; 32] {
+    pub(crate) fn random_derivation_index(rng: &mut impl RngCore) -> [u8; 32] {
         let mut bytes = [0u8; 32];
         rng.fill_bytes(&mut bytes);
         bytes

--- a/src/owner.rs
+++ b/src/owner.rs
@@ -13,7 +13,7 @@ use std::fmt;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use blsttc::{rand::distributions::Standard, rand::Rng, rand::RngCore};
+use crate::rand::{distributions::Standard, Rng, RngCore};
 
 pub type DerivationIndex = [u8; 32];
 

--- a/src/spentbook.rs
+++ b/src/spentbook.rs
@@ -12,10 +12,11 @@ use blst_ringct::{
     ringct::{OutputProof, RingCtTransaction},
     DecoyInput,
 };
-use blsttc::{rand::prelude::IteratorRandom, PublicKey};
+use blsttc::PublicKey;
 use std::collections::{BTreeMap, HashMap};
 
 use crate::{
+    rand::{prelude::IteratorRandom, RngCore},
     Commitment, GenesisMaterial, Hash, KeyImage, KeyManager, Result, SimpleKeyManager,
     SpentProofContent, SpentProofShare,
 };
@@ -213,11 +214,7 @@ impl SpentBookNodeMock {
 
     // return a list of DecoyInput built from randomly
     // selected OutputProof, from set of all OutputProof in Spentbook.
-    pub fn random_decoys(
-        &self,
-        target_num: usize,
-        rng_ct: &mut impl blst_ringct::rand::RngCore,
-    ) -> Vec<DecoyInput> {
+    pub fn random_decoys(&self, target_num: usize, rng: &mut impl RngCore) -> Vec<DecoyInput> {
         // Get a unique list of all OutputProof
         // note: Tx are duplicated in Spentbook. We use a BTreeMap
         //       with KeyImage to dedup.
@@ -240,7 +237,7 @@ impl SpentBookNodeMock {
         };
         outputs_unique
             .into_iter()
-            .choose_multiple(rng_ct, num_choose)
+            .choose_multiple(rng, num_choose)
             .into_iter()
             .map(|(_, o)| DecoyInput {
                 public_key: *o.public_key(),


### PR DESCRIPTION
<strike>note: this PR includes #154 and #157 which have not yet been merged.   If/when those are merged, this can be rebased to make a smaller diff for review.</strike>  edit: merged. this is ready for review.

----------

    feat: decouple deps and remove bls_dkg
    
    -- Change 1: re-export blsttc, blst_ringct --
    
    The idea is to give API consumers the option to use the exported crates
    without needing explicit Cargo.toml entries.
    
    This in turn decouples dependencies and reduces conflicts.
    
    See rationale/discussion here:
    https://github.com/rust-lang/api-guidelines/discussions/176
    
    -- Change 2: use deps from within blsttc, blst_ringct --
    
    blsttc and blst_ringct now reexport deps used in their public APIs.
    
    So we remove those deps from our Cargo.toml and 'use' the sub-deps
    in our code.
    
    One gross thing remains which is that both crates use rand and
    they could differ.  (although at present they are the same.)
    
    This means that sn_dbc APIs that take Rng arg to be passed to
    blsttc API can potentially be different than those that take
    an Rng arg to be passed to blst_ringct API.  Although the compiler
    presently let's us pass the same rng to both.  It's a footgun!
    
    For now, I've created an 'rng' module to make it easy to pass the
    appropriate rng, and also I updated the test cases, example, bench
    to use this methodology, to demonstrate best practice.

    Perhaps/probably a better long-term approach would be to have
    blst_ringct integrate/depend/use blsttc, so that sn_dbc has only
    a single dep and is not trying to resolve the matter.
    
    -- Change 3: remove bls_dkg dependency/feature --
    
    bls_dkg was only being used for a single function used by
    test cases.  It was simple to replace this function with
    blsttc calls which simplifies things a lot.
    
    Cargo changes:
    
    * use publshed quickcheck 1.0.3
    * use dan-da/blsttc/reexport_pr
    * remove rand, rand_core deps
    * remove xor_name dep
    * remove bls_dkg dep
    * remove dkg feature
    * remove blstrs dep
    * use single-line format for all deps. (more concise)
    
    lib.rs changes:
    * re-export blst_ringct and blsttc
    * export additional types used by builder module public API.
    * add rng module, to simplfy rng usage for callers.
    * modify bls_dkg_id() to use blsttc directly, without bls_dkg

    Code changes:
    
    * update mint-repl and reissue bench to use updated sn_dbc API.
    * update tests to separate ringct rng from blsttc rng.
    * update SimpleSigner From impl now that bls_dks is removed.

-------

edit:  Change 4: export and use a single `rand`

Our public API uses/requires rand quite prominently, with several methods requiring caller to pass in an Rng.  (The same dep issues occur for blstrs as well, but it is only indirectly exposed in sn_dbc public API).

Both blst_ringct and blsttc export rand, but they do not depend on eachother, so it is possible that they could be (in the future perhaps) using incompatible versions.  So at first glance, the cleanest seeming thing is for fn that utilize blsttc::rand to accept param of that type and fn that accept blst_ringct::rand to accept param of that type.

That is what I first impl'd but it makes using our API ugly, as sometimes callers must create both rng types in the same fn.  Worse, the compiler does not even enforce the types or issue any warning because it sees that they are *presently* using the exact same rand crate.  So it is a bit of a footgun waiting to happen for API users. I modified all the tests, examples, bench to differentiate between the two as "best practice" and found the result dis-pleasing.  We had simply gone from instantiating rng7+rng8 to rng_ringct+rng_ttc.

I made an (aborted) attempt to unify the two rand's (and blstrs) by adding a blsttc dep inside blst-bulletproofs.  So then bulletproofs uses the rand, blstrs (and I think group) from blsttc, even though it doesn't use blsttc itself.  and blst_ringct uses them from bulletproofs.  However (a) it was gross to depend on blsttc without actually using its API, and (b) it didn't truly solve the problem because from sn_dbc's perspective, there is still blst_ringct::rand and blst_ringct::bulletproofs::blsttc::rand, which could theoretically differ in the future.  So I reverted that bulletproofs commit.  (but, it remains an option.)

So finally I settled on the "solution" in https://github.com/maidsafe/sn_dbc/commit/1986cd3ba127d713d42164cef083b1423ca5efac that sn_dbc arbitrarily picks blst_ringct::rand as **the** sn_dbc rand and re-exports it.  All library code references crate::rand, including methods that pass Rng to blsttc APIs.  In doing this, sn_dbc is implicitly guaranteeing to our API users that rand (and blstrs) will remain compatible between blstrs and blsttc.  I think we can make that promise because maidsafe is planning to maintain both.  And foremost, callers were pretty much guaranteed to use it this way anyway, because the compiler allows it and it is non-obvious to use the stricter-but-correct approach.

If there is some way to make the compiler be more strict, then perhaps its better to revert https://github.com/maidsafe/sn_dbc/commit/1986cd3ba127d713d42164cef083b1423ca5efac and go with the strict approach.  Otherwise, I think this is best.... 

