### PR TITLE
fix: filter true input from decoy inputs

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -55,6 +55,7 @@ impl TransactionBuilder {
         decoy_inputs: Vec<DecoyInput>,
         rng: &mut impl RngCore,
     ) -> Self {
+        let decoy_inputs = Self::filter_decoys(&true_input, decoy_inputs);
         self.ringct_material
             .inputs
             .push(MlsagMaterial::new(true_input, decoy_inputs, rng));
@@ -129,10 +130,7 @@ impl TransactionBuilder {
         rng: &mut impl RngCore,
     ) -> Self {
         let true_input = TrueInput::new(secret_key, amount_secrets.into());
-
-        self.ringct_material
-            .inputs
-            .push(MlsagMaterial::new(true_input, decoy_inputs, rng));
+        self = self.add_input_by_true_input(true_input, decoy_inputs, rng);
         self
     }
 
@@ -229,6 +227,14 @@ impl TransactionBuilder {
             self.output_owner_map,
             self.ringct_material,
         ))
+    }
+
+    // removes TrueInput from DecoyInputs, if present
+    fn filter_decoys(true_input: &TrueInput, decoy_inputs: Vec<DecoyInput>) -> Vec<DecoyInput> {
+        decoy_inputs
+            .into_iter()
+            .filter(|d| d.public_key() != true_input.public_key().to_affine())
+            .collect()
     }
 }
 


### PR DESCRIPTION
Previously it was possible to have the true input
included amongst the decoy inputs.

blst-ringct [now validates](https://github.com/maidsafe/blst-ringct/pull/13) against this happening, so the client must prevent it.

The chosen fix is for TransactionBuilder to filter
out the true input from the decoys if the caller should
mistakenly include it.

This removes the burden of checking/filtering from the
caller.  With the possible side-effect that the number of
decoy inputs is reduced by one.  However, if the caller
is concerned about this, it can verify for itself that
the true input is not present.

Another possibility would be for SpentbookNodeMock::random_decoy()
to accept a TrueInput arg, and it could avoid returning that
input.  However this would inform the Spentbook node of the true
input, so we do not use this approach.