### PR TITLE
feat: serialize blsttc and ringct error variants

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ ringct-serde = [ "blst_ringct/serde" ]
 
 [dependencies]
 thiserror = "1.0.24"
-blsttc = "5.1.2"
+blsttc = "5.2.0"
 hex = "0.4.3"
 
   [dependencies.blst_ringct]

--- a/src/error.rs
+++ b/src/error.rs
@@ -80,12 +80,10 @@ pub enum Error {
     #[error("The transaction input has {0:?} public keys but found {1:?} matching outputs in spentbook.")]
     SpentbookRingSizeMismatch(usize, usize),
 
-    #[cfg_attr(feature = "serde", serde(skip))]
     #[error("Bls error: {0}")]
     Blsttc(#[from] blsttc::error::Error),
 
     /// blst_ringct error.
-    #[cfg_attr(feature = "serde", serde(skip))]
     #[error("ringct error: {0}")]
     RingCt(#[from] blst_ringct::Error),
 


### PR DESCRIPTION
necessary for serializing RingCt and Blsttc error variants over the network.  needed by dbc playground, and (possibly?) by future wallet(s).  

note: the cargo dep changes are temporary until similar PRs in blst-ringct and blsttc are merged.  Once they are merged, I will update this PR.