### PR TITLE
fix: avoid true input inclusion in decoys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,8 @@ rustyline = "8.0.0"
 bincode = "1.3.3"
 criterion = "0.3.5"
 
-  [dev-dependencies.pprof]
+# pprof is not building on windows, mac
+[target."cfg(unix)".dev-dependencies.pprof]
   version = "0.7.0"
   features = [ "flamegraph" ]
 
@@ -49,6 +50,8 @@ criterion = "0.3.5"
 [target."cfg(unix)".dev-dependencies]
 termios = "0.3.3"
 
+# pprof is not building on windows, mac
+[target.'cfg(unix)']
 [[bench]]
 name = "reissue"
 harness = false

--- a/benches/reissue.rs
+++ b/benches/reissue.rs
@@ -25,6 +25,7 @@ fn bench_reissue_1_to_100(c: &mut Criterion) {
         generate_dbc_of_value(N_OUTPUTS as Amount, &mut rng).unwrap();
 
     let mut dbc_builder = sn_dbc::TransactionBuilder::default()
+        .set_require_all_decoys(false) // no decoys!
         .add_input_by_secrets(
             starting_dbc
                 .owner_once_bearer()
@@ -32,8 +33,6 @@ fn bench_reissue_1_to_100(c: &mut Criterion) {
                 .secret_key()
                 .unwrap(),
             starting_dbc.amount_secrets_bearer().unwrap(),
-            vec![], // never any decoys for genesis
-            &mut rng,
         )
         .add_outputs_by_amount((0..N_OUTPUTS).into_iter().map(|_| {
             let owner_once =
@@ -69,12 +68,12 @@ fn bench_reissue_1_to_100(c: &mut Criterion) {
 
 fn bench_reissue_100_to_1(c: &mut Criterion) {
     let mut rng = rng::from_seed([0u8; 32]);
-    let num_decoys = 0;
 
     let (mut spentbook_node, starting_dbc) =
         generate_dbc_of_value(N_OUTPUTS as Amount, &mut rng).unwrap();
 
     let mut dbc_builder = sn_dbc::TransactionBuilder::default()
+        .set_require_all_decoys(false) // no decoys!
         .add_input_by_secrets(
             starting_dbc
                 .owner_once_bearer()
@@ -82,8 +81,6 @@ fn bench_reissue_100_to_1(c: &mut Criterion) {
                 .secret_key()
                 .unwrap(),
             starting_dbc.amount_secrets_bearer().unwrap(),
-            vec![], // never any decoy inputs for genesis
-            &mut rng,
         )
         .add_outputs_by_amount((0..N_OUTPUTS).into_iter().map(|_| {
             let owner_once =
@@ -103,17 +100,13 @@ fn bench_reissue_100_to_1(c: &mut Criterion) {
         OwnerOnce::from_owner_base(Owner::from_random_secret_key(&mut rng), &mut rng);
 
     let mut merge_dbc_builder = sn_dbc::TransactionBuilder::default()
+        .set_require_all_decoys(false) // no decoys!
         .add_inputs_by_secrets(
             dbcs.into_iter()
                 .map(|(_dbc, owner_once, amount_secrets)| {
-                    (
-                        owner_once.as_owner().secret_key().unwrap(),
-                        amount_secrets,
-                        spentbook_node.random_decoys(num_decoys, &mut rng),
-                    )
+                    (owner_once.as_owner().secret_key().unwrap(), amount_secrets)
                 })
                 .collect(),
-            &mut rng,
         )
         .add_output_by_amount(N_OUTPUTS as Amount, output_owner_once)
         .build(&mut rng)
@@ -153,11 +146,10 @@ fn generate_dbc_of_value(
     let output_amounts = vec![amount, sn_dbc::GenesisMaterial::GENESIS_AMOUNT - amount];
 
     let mut dbc_builder = sn_dbc::TransactionBuilder::default()
+        .set_require_all_decoys(false) // no decoys!
         .add_input_by_secrets(
             genesis_dbc.owner_once_bearer()?.secret_key()?,
             genesis_dbc.amount_secrets_bearer()?,
-            vec![], // never any decoys for genesis
-            rng,
         )
         .add_outputs_by_amount(output_amounts.into_iter().map(|amount| {
             let owner_once = OwnerOnce::from_owner_base(Owner::from_random_secret_key(rng), rng);

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -29,15 +29,83 @@ pub type OutputOwnerMap = BTreeMap<PublicKey, OwnerOnce>;
 /// A builder to create a RingCt transaction from
 /// inputs and outputs.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct TransactionBuilder {
+    true_inputs: Vec<TrueInput>,
     ringct_material: RingCtMaterial,
     output_owner_map: OutputOwnerMap,
+    available_decoys: Vec<DecoyInput>,
+    decoys_per_input: usize,
+    require_all_decoys: bool,
+}
+
+impl Default for TransactionBuilder {
+    fn default() -> Self {
+        Self {
+            true_inputs: Default::default(),
+            ringct_material: Default::default(),
+            output_owner_map: Default::default(),
+            available_decoys: Default::default(),
+            decoys_per_input: 10, // default to 10 decoys per input.
+            require_all_decoys: true,
+        }
+    }
 }
 
 impl TransactionBuilder {
+    /// set decoys_per_input option.
+    /// allocate this many decoys to each input (from available_decoys).
+    pub fn set_decoys_per_input(mut self, decoys_per_input: usize) -> Self {
+        self.decoys_per_input = decoys_per_input;
+        self
+    }
+
+    /// set require_all_decoys option.
+    /// if true, we require <decoys_per_input> for every (true) input.
+    pub fn set_require_all_decoys(mut self, require_all_decoys: bool) -> Self {
+        self.require_all_decoys = require_all_decoys;
+        self
+    }
+
+    /// add to pool of available decoys.
+    ///
+    /// It is best that the size of the pool is larger (even much larger)
+    /// than <decoys_per_input> * true_inputs.len().
+    ///
+    /// Especially because it is possible that 1 or more of these
+    /// is actually a true input, which will not be discovered until
+    /// ::build() is called.
+    pub fn add_decoy_inputs(mut self, decoy_inputs: Vec<DecoyInput>) -> Self {
+        let available_decoys = self.available_decoys.clone();
+        let new_decoys = decoy_inputs.iter().filter(|new| {
+            !available_decoys
+                .iter()
+                .any(|old| old.public_key() == new.public_key())
+        });
+        self.available_decoys.extend(new_decoys);
+        self
+    }
+
     /// add an input given an MlsagMaterial
     pub fn add_input(mut self, mlsag: MlsagMaterial) -> Self {
+        // This requires a little explanation.
+        //
+        // We add the true input to our true_inputs list. This simplifies
+        // the methods ::true_inputs() and ::inputs_owners() and
+        // ::inputs_amount_sum(), which can operate on true_inputs alone.
+        //
+        // Finally in ::build(), any dups in true_inputs are removed,
+        // and the remaining true_inputs are added to ringct_material.inputs.
+        //
+        // you asK: why not just put all inputs in ringct_material.inputs?
+        //
+        // answer:
+        //   1. it would require an extra rng arg to all the other add_input*
+        //      fns, which is ugly.
+        //   2. it requires knowing the DecoyInputs in advance, which we can't
+        //      really know until we know all the true inputs because we have
+        //      to ensure that no true input is used as a decoy input.
+        self = self.add_true_input(mlsag.true_input.clone());
         self.ringct_material.inputs.push(mlsag);
         self
     }
@@ -48,75 +116,47 @@ impl TransactionBuilder {
         self
     }
 
-    /// add an input given a TrueInput and decoy list
-    pub fn add_input_by_true_input(
-        mut self,
-        true_input: TrueInput,
-        decoy_inputs: Vec<DecoyInput>,
-        rng: &mut impl RngCore,
-    ) -> Self {
-        let decoy_inputs = Self::filter_decoys(&true_input, decoy_inputs);
-        self.ringct_material
-            .inputs
-            .push(MlsagMaterial::new(true_input, decoy_inputs, rng));
+    /// add an input given a TrueInput
+    pub fn add_true_input(mut self, true_input: TrueInput) -> Self {
+        self.true_inputs.push(true_input);
         self
     }
 
     /// add an input given a list of TrueInputs and associated decoys
-    pub fn add_inputs_by_true_inputs(
-        mut self,
-        inputs: impl IntoIterator<Item = (TrueInput, Vec<DecoyInput>)>,
-        rng: &mut impl RngCore,
-    ) -> Self {
-        for (true_input, decoy_inputs) in inputs.into_iter() {
-            self = self.add_input_by_true_input(true_input, decoy_inputs, rng);
+    pub fn add_true_inputs(mut self, inputs: impl IntoIterator<Item = TrueInput>) -> Self {
+        for true_input in inputs.into_iter() {
+            self = self.add_true_input(true_input);
         }
         self
     }
 
     /// add an input given a Dbc, SecretKey and decoy list
-    pub fn add_input_dbc(
-        mut self,
-        dbc: &Dbc,
-        base_sk: &SecretKey,
-        decoy_inputs: Vec<DecoyInput>,
-        rng: &mut impl RngCore,
-    ) -> Result<Self> {
-        self = self.add_input_by_true_input(dbc.as_true_input(base_sk)?, decoy_inputs, rng);
+    pub fn add_input_dbc(mut self, dbc: &Dbc, base_sk: &SecretKey) -> Result<Self> {
+        self = self.add_true_input(dbc.as_true_input(base_sk)?);
         Ok(self)
     }
 
     /// add an input given a list of Dbcs and associated SecretKey and decoys
     pub fn add_inputs_dbc(
         mut self,
-        dbcs: impl IntoIterator<Item = (Dbc, SecretKey, Vec<DecoyInput>)>,
-        rng: &mut impl RngCore,
+        dbcs: impl IntoIterator<Item = (Dbc, SecretKey)>,
     ) -> Result<Self> {
-        for (dbc, base_sk, decoy_inputs) in dbcs.into_iter() {
-            self = self.add_input_dbc(&dbc, &base_sk, decoy_inputs, rng)?;
+        for (dbc, base_sk) in dbcs.into_iter() {
+            self = self.add_input_dbc(&dbc, &base_sk)?;
         }
         Ok(self)
     }
 
     /// add an input given a bearer Dbc, SecretKey and decoy list
-    pub fn add_input_dbc_bearer(
-        mut self,
-        dbc: &Dbc,
-        decoy_inputs: Vec<DecoyInput>,
-        rng: &mut impl RngCore,
-    ) -> Result<Self> {
-        self = self.add_input_by_true_input(dbc.as_true_input_bearer()?, decoy_inputs, rng);
+    pub fn add_input_dbc_bearer(mut self, dbc: &Dbc) -> Result<Self> {
+        self = self.add_true_input(dbc.as_true_input_bearer()?);
         Ok(self)
     }
 
     /// add an input given a list of bearer Dbcs and associated SecretKey and decoys
-    pub fn add_inputs_dbc_bearer(
-        mut self,
-        dbcs: impl IntoIterator<Item = (Dbc, Vec<DecoyInput>)>,
-        rng: &mut impl RngCore,
-    ) -> Result<Self> {
-        for (dbc, decoy_inputs) in dbcs.into_iter() {
-            self = self.add_input_dbc_bearer(&dbc, decoy_inputs, rng)?;
+    pub fn add_inputs_dbc_bearer(mut self, dbcs: impl IntoIterator<Item = Dbc>) -> Result<Self> {
+        for dbc in dbcs.into_iter() {
+            self = self.add_input_dbc_bearer(&dbc)?;
         }
         Ok(self)
     }
@@ -126,22 +166,16 @@ impl TransactionBuilder {
         mut self,
         secret_key: SecretKey,
         amount_secrets: AmountSecrets,
-        decoy_inputs: Vec<DecoyInput>,
-        rng: &mut impl RngCore,
     ) -> Self {
         let true_input = TrueInput::new(secret_key, amount_secrets.into());
-        self = self.add_input_by_true_input(true_input, decoy_inputs, rng);
+        self = self.add_true_input(true_input);
         self
     }
 
     /// add an input given a list of (SecretKey, AmountSecrets, and list of decoys)
-    pub fn add_inputs_by_secrets(
-        mut self,
-        secrets: Vec<(SecretKey, AmountSecrets, Vec<DecoyInput>)>,
-        rng: &mut impl RngCore,
-    ) -> Self {
-        for (secret_key, amount_secrets, decoy_inputs) in secrets.into_iter() {
-            self = self.add_input_by_secrets(secret_key, amount_secrets, decoy_inputs, rng);
+    pub fn add_inputs_by_secrets(mut self, secrets: Vec<(SecretKey, AmountSecrets)>) -> Self {
+        for (secret_key, amount_secrets) in secrets.into_iter() {
+            self = self.add_input_by_secrets(secret_key, amount_secrets);
         }
         self
     }
@@ -182,21 +216,19 @@ impl TransactionBuilder {
         self
     }
 
-    /// get a list of input owners
+    /// get a list of input (true) owners
     pub fn input_owners(&self) -> Vec<PublicKey> {
-        self.ringct_material
-            .public_keys()
+        self.true_inputs
             .iter()
-            .map(|pk| (*pk).into())
+            .map(|t| t.public_key().into())
             .collect()
     }
 
     /// get sum of input amounts
     pub fn inputs_amount_sum(&self) -> Amount {
-        self.ringct_material
-            .inputs
+        self.true_inputs
             .iter()
-            .map(|m| m.true_input.revealed_commitment.value)
+            .map(|t| t.revealed_commitment.value)
             .sum()
     }
 
@@ -205,9 +237,9 @@ impl TransactionBuilder {
         self.ringct_material.outputs.iter().map(|o| o.amount).sum()
     }
 
-    /// get inputs
-    pub fn inputs(&self) -> &Vec<MlsagMaterial> {
-        &self.ringct_material.inputs
+    /// get true inputs
+    pub fn inputs(&self) -> &Vec<TrueInput> {
+        &self.true_inputs
     }
 
     /// get outputs
@@ -216,25 +248,76 @@ impl TransactionBuilder {
     }
 
     /// build a RingCtTransaction and associated secrets
-    pub fn build(self, rng: impl RngCore + CryptoRng) -> Result<DbcBuilder> {
+    pub fn build(self, mut rng: impl RngCore + CryptoRng) -> Result<DbcBuilder> {
+        let mut ringct_material = self.ringct_material;
+        let mut true_inputs = self.true_inputs;
+
+        // get public_keys of all true_inputs.
+        let true_public_keys: Vec<_> = true_inputs
+            .iter()
+            .map(|true_input| true_input.public_key().to_affine())
+            .collect();
+        // remove any available decoys that are actually true inputs.
+        let available_decoys: Vec<_> = self
+            .available_decoys
+            .into_iter()
+            .filter(|d| true_public_keys.iter().all(|pk| *pk != d.public_key()))
+            .collect();
+
+        // remove any true inputs that are already in self.ringct_material.inputs
+        // see comment in ::add_input() for explanation.
+        true_inputs.retain(|true_input| {
+            !ringct_material
+                .inputs
+                .iter()
+                .any(|m| m.true_input.public_key() == true_input.public_key())
+        });
+
+        // calc total number of decoys required for Tx.
+        let num_required_decoys = true_inputs.len() * self.decoys_per_input;
+        if self.require_all_decoys && available_decoys.len() < num_required_decoys {
+            return Err(Error::InsufficientDecoys);
+        }
+
+        // group available decoys into sets of <decoys_per_input>.
+        let mut decoy_inputs_chunks: Vec<&[DecoyInput]> = match self.decoys_per_input {
+            0 => vec![], // ::chunks() panics if chunk-size is zero.
+            _ => available_decoys.chunks(self.decoys_per_input).collect(),
+        };
+
+        // if we don't have enough sets of decoys, then we need to add any
+        // missing sets, to match true_inputs.len()
+        let empty: Vec<DecoyInput> = vec![];
+        if decoy_inputs_chunks.len() < true_inputs.len() {
+            assert!(!self.require_all_decoys);
+            assert!(num_required_decoys == 0 || num_required_decoys > available_decoys.len());
+
+            // pad to true_inputs.len with empty vec(s).
+            while decoy_inputs_chunks.len() < true_inputs.len() {
+                decoy_inputs_chunks.push(&empty);
+            }
+        }
+
+        // create our final ringct inputs, with decoys.
+        for (true_input, decoy_inputs) in true_inputs.into_iter().zip(decoy_inputs_chunks) {
+            ringct_material.inputs.push(MlsagMaterial::new(
+                true_input,
+                decoy_inputs.to_vec(),
+                &mut rng,
+            ));
+        }
+
+        // Grand finale!  sign the ringct_material to generate a Tx.
         let result: Result<(RingCtTransaction, Vec<RevealedCommitment>)> =
-            self.ringct_material.sign(rng).map_err(|e| e.into());
+            ringct_material.sign(rng).map_err(|e| e.into());
         let (transaction, revealed_commitments) = result?;
 
         Ok(DbcBuilder::new(
             transaction,
             revealed_commitments,
             self.output_owner_map,
-            self.ringct_material,
+            ringct_material,
         ))
-    }
-
-    // removes TrueInput from DecoyInputs, if present
-    fn filter_decoys(true_input: &TrueInput, decoy_inputs: Vec<DecoyInput>) -> Vec<DecoyInput> {
-        decoy_inputs
-            .into_iter()
-            .filter(|d| d.public_key() != true_input.public_key().to_affine())
-            .collect()
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -66,6 +66,9 @@ pub enum Error {
     #[error("Public key not found")]
     PublicKeyNotFound,
 
+    #[error("Insufficient decoys available for all inputs")]
+    InsufficientDecoys,
+
     #[error("Secret key does not match public key")]
     SecretKeyDoesNotMatchPublicKey,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,6 +136,9 @@ mod tests {
     use core::num::NonZeroU8;
     use quickcheck::{Arbitrary, Gen};
 
+    pub const STD_DECOYS_PER_INPUT: usize = 3;
+    pub const STD_DECOYS_TO_FETCH: usize = 100;
+
     #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
     pub struct TinyInt(pub u8);
 
@@ -195,7 +198,7 @@ mod tests {
     }
 
     #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
-    pub struct TinyVec<T>(Vec<T>);
+    pub struct TinyVec<T>(pub Vec<T>);
 
     impl<T> TinyVec<T> {
         pub fn into_iter(self) -> impl Iterator<Item = T> {


### PR DESCRIPTION
We've had some tests cases failing because blst-ringct now verifies
that every public_key referenced by a Tx input is unique.  But
the test cases were obtaining a set of (possibly duplicate) random
decoys for each input. So these decoys could duplicate eachother
and also any of them could also be a true input.

The fix is to refactor TransactionBuilder such that:
1. DecoyInputs are added to a decoy pool within the builder,
and the builder removes dups from the pool.
2. ::build() removes any true inputs from the decoys pool
and then distributes decoys from the pool amongst the inputs.
3. If there are not enough decoys in the pool then an error
is returned -- unless the 'require_all_decoys' setting is false,
in which case any remaining inputs receive no decoys.

Cargo changes:
* only build pprof and benches on unix/linux

Code changes:
* update tests, bench, mint-repl to use modified builder API
* add fields to TransactionBuilder
* add decoys_per_input field and set default to 10.
* rename TransactionBuilder::add_input_by_true_input to add_true_input()
* add API TransactionBuilder::set_decoys_per_input()
* add API TransactionBuilder::set_require_all_inputs()
* add API TransactionBuilder::add_decoy_inputs()
* modify TransactionBuilder::build() to filter true inputs from decoys
  and distribute decoys amongst inputs
* add Error::InsufficientDecoys