### PR TITLE
chore: reference renamed ringct crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,44 +11,35 @@ edition = "2018"
 
 [features]
 serdes = [ "serde", "ringct-serde" ]
-ringct-serde = [ "sn_ringct/serde" ]
+ringct-serde = [ "bls_ringct/serde" ]
 mock = [ ]
 
 [dependencies]
-thiserror = "1.0.24"
 blsttc = "5.2.0"
+bls_ringct = "0.1.0"
 hex = "0.4.3"
-
-  [dependencies.sn_ringct]
-  version = "0.1.0"
-
-  [dependencies.tiny-keccak]
-  version = "2.0.0"
-  features = [ "sha3" ]
-
-  [dependencies.serde]
-  version = "1.0.133"
-  features = [ "derive", "rc" ]
-  optional = true
+serde = { version = "1.0.133", features = [ "derive", "rc" ], optional = true }
+thiserror = "1.0.24"
+tiny-keccak = { features = [ "sha3" ], version = "2.0.0" }
 
 [dev-dependencies]
-quickcheck_macros = "1"
-quickcheck = "1.0.3"
 anyhow = "1.0.40"
-rustyline = "8.0.0"
 bincode = "1.3.3"
 criterion = "0.3.5"
+quickcheck_macros = "1"
+quickcheck = "1.0.3"
+rustyline = "8.0.0"
 
-  [dev-dependencies.sn_dbc]
-  path = "."
-  features = [ "serdes", "mock" ]
+[dev-dependencies.sn_dbc]
+path = "."
+features = [ "serdes", "mock" ]
 
 [target."cfg(unix)".dev-dependencies]
 termios = "0.3.3"
 
-  [target."cfg(unix)".dev-dependencies.pprof]
-  version = "0.7.0"
-  features = [ "flamegraph" ]
+[target."cfg(unix)".dev-dependencies.pprof]
+version = "0.7.0"
+features = [ "flamegraph" ]
 
 [[bench]]
 name = "reissue"

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ $ cargo test
 
 This crate depends most heavily on:
 
-- [sn_ringct](https://github.com/maidsafe/sn_ringct/) - RingCt using bls curve
+- [bls_ringct](https://github.com/maidsafe/bls_ringct/) - RingCt using bls curve
 - [blsttc](https://github.com/maidsafe/blsttc/) - BLS keys
 
 

--- a/src/amount_secrets.rs
+++ b/src/amount_secrets.rs
@@ -8,16 +8,15 @@
 
 use crate::rand::RngCore;
 use crate::{BlindingFactor, Error};
+use bls_ringct::RevealedCommitment;
 use blsttc::{
     Ciphertext, DecryptionShare, IntoFr, PublicKey, PublicKeySet, SecretKey, SecretKeySet,
     SecretKeyShare,
 };
-use sn_ringct::RevealedCommitment;
 use std::collections::BTreeMap;
 use std::convert::TryFrom;
 
-// we re-export this.
-pub use sn_ringct::ringct::Amount;
+pub use bls_ringct::ringct::Amount;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -25,14 +24,14 @@ use serde::{Deserialize, Serialize};
 const AMT_SIZE: usize = std::mem::size_of::<Amount>(); // Amount size: 8 bytes (u64)
 const BF_SIZE: usize = std::mem::size_of::<BlindingFactor>(); // Blinding factor size: 32 bytes (BlindingFactor)
 
-/// AmountSecrets wraps sn_ringct::RevealedCommitment to provide some methods
+/// AmountSecrets wraps bls_ringct::RevealedCommitment to provide some methods
 /// for ergonomic usage, eg: decrypting from Ciphertext using various blsttc
 /// components, eg SecretKey, SecretKeyShare, SecretKeySet, DecryptionShare
 //
 // todo: perhaps AmountSecrets should be renamed to be more consistent with
 //  RevealedCommitment, since it is just a NewType wrapper.
 //
-// Once sn_ringct uses blsttc, perhaps AmountSecrets functionality could
+// Once bls_ringct uses blsttc, perhaps AmountSecrets functionality could
 //  move into RevealedCommitment, and AmountSecrets goes away entirely.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]

--- a/src/blst.rs
+++ b/src/blst.rs
@@ -18,10 +18,10 @@
 //! crates consistent.
 
 /// a Commitment
-pub type Commitment = sn_ringct::blstrs::G1Affine;
+pub type Commitment = bls_ringct::blstrs::G1Affine;
 
 /// a BlindingFactor
-pub type BlindingFactor = sn_ringct::blstrs::Scalar;
+pub type BlindingFactor = bls_ringct::blstrs::Scalar;
 
 /// A KeyImage can be thought of as a specific type
 /// of public key. blsttc::PublicKey is a newtype

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -6,12 +6,12 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use blsttc::{PublicKey, SecretKey};
-use sn_ringct::{group::Curve, ringct::Amount, sn_bulletproofs::PedersenGens};
-pub use sn_ringct::{
+use bls_ringct::{bls_bulletproofs::PedersenGens, group::Curve, ringct::Amount};
+pub use bls_ringct::{
     ringct::RingCtTransaction, DecoyInput, MlsagMaterial, Output, RevealedCommitment,
     RingCtMaterial, TrueInput,
 };
+use blsttc::{PublicKey, SecretKey};
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 use crate::{

--- a/src/error.rs
+++ b/src/error.rs
@@ -75,11 +75,9 @@ pub enum Error {
     #[error("Bls error: {0}")]
     Blsttc(#[from] blsttc::error::Error),
 
-    /// sn_ringct error.
     #[error("ringct error: {0}")]
-    RingCt(#[from] sn_ringct::Error),
+    RingCt(#[from] bls_ringct::Error),
 
-    // mock error.
     #[cfg(feature = "mock")]
     #[error("mock object error")]
     Mock(#[from] crate::mock::Error),

--- a/src/genesis.rs
+++ b/src/genesis.rs
@@ -1,12 +1,12 @@
 use crate::{Amount, KeyImage, Owner, OwnerOnce};
-use blsttc::IntoFr;
-use sn_ringct::{
+use bls_ringct::{
     blstrs::Scalar,
     group::Curve,
     mlsag::{MlsagMaterial, TrueInput},
     ringct::RingCtMaterial,
     {Output, RevealedCommitment},
 };
+use blsttc::IntoFr;
 
 /// represents all the inputs required to build the Genesis Dbc.
 pub struct GenesisMaterial {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,15 +25,15 @@ mod verification;
 pub mod mock;
 
 // re-export crates used in our public API
+pub use bls_ringct;
 pub use blsttc;
-pub use sn_ringct;
-// note: both sn_ringct::rand and blsttc::rand are
+// note: both bls_ringct::rand and blsttc::rand are
 // exposed in our public API.  Here, by choosing
 // just one, we are making an implicit promise that
 // the two versions will remain compatible, or that
 // our API will reconcile the difference.  We do
 // this knowingly and pledge to uphold that promise.
-pub use sn_ringct::rand;
+pub use bls_ringct::rand;
 
 pub use crate::{
     amount_secrets::{Amount, AmountSecrets},

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -71,13 +71,13 @@ mod tests {
         let check_error = |error: Error| -> Result<()> {
             match error {
                 Error::RingCt(
-                    sn_ringct::Error::InputPseudoCommitmentsDoNotSumToOutputCommitments,
+                    bls_ringct::Error::InputPseudoCommitmentsDoNotSumToOutputCommitments,
                 ) => {
                     // Verify that no outputs were present and we got correct verification error.
                     assert_eq!(n_outputs, 0);
                     Ok(())
                 }
-                Error::RingCt(sn_ringct::Error::InvalidHiddenCommitmentInRing) => {
+                Error::RingCt(bls_ringct::Error::InvalidHiddenCommitmentInRing) => {
                     // Verify that no outputs were present and we got correct verification error.
                     assert_eq!(n_outputs, 0);
                     Ok(())
@@ -183,7 +183,7 @@ mod tests {
         let check_tx_error = |error: Error| -> Result<()> {
             match error {
                 Error::RingCt(
-                    sn_ringct::Error::InputPseudoCommitmentsDoNotSumToOutputCommitments,
+                    bls_ringct::Error::InputPseudoCommitmentsDoNotSumToOutputCommitments,
                 ) => {
                     // Verify that no inputs were present and we got correct verification error.
                     assert!(input_amounts.is_empty());
@@ -246,7 +246,7 @@ mod tests {
                     assert!(!invalid_spent_proofs.is_empty());
                 }
                 Error::RingCt(
-                    sn_ringct::Error::InputPseudoCommitmentsDoNotSumToOutputCommitments,
+                    bls_ringct::Error::InputPseudoCommitmentsDoNotSumToOutputCommitments,
                 ) => {
                     if GenesisMaterial::GENESIS_AMOUNT == output_total_amount {
                         // This can correctly occur if there are 0 outputs and inputs sum to zero.
@@ -259,10 +259,10 @@ mod tests {
                         assert!(!input_amounts.is_empty());
                     }
                 }
-                Error::RingCt(sn_ringct::Error::InvalidHiddenCommitmentInRing) => {
+                Error::RingCt(bls_ringct::Error::InvalidHiddenCommitmentInRing) => {
                     assert!(!invalid_spent_proofs.is_empty());
                 }
-                Error::RingCt(sn_ringct::Error::TransactionMustHaveAnInput) => {
+                Error::RingCt(bls_ringct::Error::TransactionMustHaveAnInput) => {
                     assert_eq!(input_amounts.len(), 0);
                 }
                 Error::FailedSignature => {
@@ -550,7 +550,7 @@ mod tests {
 
         for (key_image, tx) in dbc_builder_fudged.inputs() {
             match spentbook.log_spent(key_image, tx) {
-                Err(Error::RingCt(sn_ringct::Error::InvalidHiddenCommitmentInRing)) => {}
+                Err(Error::RingCt(bls_ringct::Error::InvalidHiddenCommitmentInRing)) => {}
                 _ => panic!("Expecting RingCt Error::InvalidHiddenCommitmentInRing"),
             }
         }
@@ -571,7 +571,7 @@ mod tests {
         let result_fudged = dbc_builder_fudged.build(&spentbook.key_manager);
 
         match result_fudged {
-            Err(Error::RingCt(sn_ringct::Error::InvalidHiddenCommitmentInRing)) => {}
+            Err(Error::RingCt(bls_ringct::Error::InvalidHiddenCommitmentInRing)) => {}
             _ => panic!("Expecting RingCt Error::InvalidHiddenCommitmentInRing"),
         }
 

--- a/src/mock/spentbook.rs
+++ b/src/mock/spentbook.rs
@@ -6,13 +6,13 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use blsttc::PublicKey;
-use sn_ringct::{
+use bls_ringct::{
+    bls_bulletproofs::PedersenGens,
     group::Curve,
     ringct::{OutputProof, RingCtTransaction},
-    sn_bulletproofs::PedersenGens,
     DecoyInput,
 };
+use blsttc::PublicKey;
 use std::collections::{BTreeMap, HashMap};
 
 use crate::{

--- a/src/verification.rs
+++ b/src/verification.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::{Commitment, Error, Hash, KeyImage, KeyManager, Result, SpentProof};
-use sn_ringct::ringct::RingCtTransaction;
+use bls_ringct::ringct::RingCtTransaction;
 use std::collections::BTreeSet;
 
 // Here we are putting transaction verification logic that is beyond


### PR DESCRIPTION
BREAKING CHANGE: The sn_ringct crate was renamed to bls_ringct, so we update this reference.