### PR TITLE
ci: remove code coverage from pr workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,7 +9,6 @@ on: pull_request
 
 env:
   RUST_BACKTRACE: 1
-  # Deny all compiler warnings.
   RUSTFLAGS: "-D warnings"
 
 jobs:
@@ -19,7 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      # Install Rust and required components
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -27,7 +25,6 @@ jobs:
           override: true
           components: rustfmt, clippy
 
-      # Cache.
       - name: Cargo cache registry, index and build
         uses: actions/cache@v2.1.4
         with:
@@ -37,11 +34,9 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('**/Cargo.toml') }}
 
-      # Check if the code is formatted correctly.
       - name: Check formatting
         run: cargo fmt --all -- --check
 
-      # Run Clippy.
       - name: Clippy checks
         run: cargo clippy --all-targets
 
@@ -56,48 +51,6 @@ jobs:
       - uses: maidsafe/pr_size_checker@v2
         with:
           max_lines_changed: 200
-  
-  coverage:
-    if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"
-    name: Code coverage check
-    runs-on: ubuntu-latest
-    env: 
-      PROPTEST_CASES: 1
-    steps:
-      - uses: actions/checkout@v2
-      # Install Rust
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      # Cache.
-      - name: Cargo cache registry, index and build
-        uses: actions/cache@v2.1.4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
-
-      # Run cargo tarpaulin & push result to coveralls.io
-      - name: rust-tarpaulin code coverage check
-        uses: actions-rs/tarpaulin@v0.1
-        with:
-          args: '-v --release --out Lcov'
-      - name: Push code coverage results to coveralls.io
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel: true
-          path-to-lcov: ./lcov.info
-      - name: Coveralls Finished
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel-finished: true
 
   cargo-udeps:
     if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"
@@ -105,7 +58,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      # Install Rust and required components
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
@@ -123,7 +75,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    # wget the shared deny.toml file from the QA repo
     - shell: bash
       run: wget https://raw.githubusercontent.com/maidsafe/QA/master/misc-scripts/deny.toml
 
@@ -138,14 +89,12 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
       - uses: actions/checkout@v2
-      # Install Rust
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
 
-      # Cache.
       - name: Cargo cache registry, index and build
         uses: actions/cache@v2.1.4
         with:
@@ -154,21 +103,18 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
-      
-      # Run tests.
+
       - uses: actions-rs/cargo@v1
         with:
           command: test
           args: --release
 
-  # Test publish using --dry-run.
   test-publish:
     if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"
     name: Test Publish
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      # Install Rust
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal


### PR DESCRIPTION
This was always failing and in any case, wasn't being used.

Also took the opportunity to remove superfluous comments from the workflow.