### PR TITLE
feat: convert owned dbc to bearer

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -78,6 +78,9 @@ pub enum Error {
     #[error("Could not serialize DBC to hex: {0}")]
     HexSerializationFailed(String),
 
+    #[error("Could not convert owned DBC to bearer: {0}")]
+    DbcBearerConversionFailed(String),
+
     #[error("Bls error: {0}")]
     Blsttc(#[from] blsttc::error::Error),
 

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -446,7 +446,7 @@ mod tests {
         let output_amount = 1000;
 
         let (mut spentbook, genesis_dbc, starting_dbc, _change_dbc) =
-            crate::dbc::tests::generate_dbc_of_value(output_amount, &mut rng)?;
+            crate::dbc::tests::generate_bearer_dbc_of_value(output_amount, &mut rng)?;
 
         // ----------
         // 2. spend genesis DBC (a) to Dbc (b)  with value 1000.


### PR DESCRIPTION
Converts an owned DBC (one whose owner is a public key and can only be spent by the holder of that
key), to a bearer DBC (one whose owner is a secret key). When an owned DBC is reissued/spent, the
secret key must be supplied.

The purpose of this is to make it easier to spend owned DBCs. Our plan is to supply the secret key
for the owned DBC when it's deposited in a wallet. At that point it will be converted to a bearer,
then when it is used as an input on the next reissue, the secret key has already been supplied.
Since there can be many input DBCs on a reissue, we avoid an issue with trying to map different
secret keys to different inputs.