### PR TITLE
chore: update blsttc to 6.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ mock = [ ]
 
 [dependencies]
 bincode = "1.3.3"
-blsttc = "5.2.0"
+blsttc = "6.0.0"
 bls_ringct = "0.2.0"
 hex = "0.4.3"
 thiserror = "1.0.24"

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,13 +9,9 @@ use thiserror::Error;
 
 use crate::KeyImage;
 
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-
 /// Specialisation of `std::Result`.
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[allow(clippy::large_enum_variant)]
 #[derive(Error, Debug, Clone)]
 #[non_exhaustive]
@@ -91,7 +87,6 @@ pub enum Error {
     #[error("mock object error")]
     Mock(#[from] crate::mock::Error),
 
-    #[cfg_attr(feature = "serde", serde(skip))]
     #[error("Infallible.  Can never fail")]
     Infallible(#[from] std::convert::Infallible),
 }


### PR DESCRIPTION
BREAKING CHANGE: a change from the blsttc release cascades here to require the error type to remove derivation from `Serialize` and `Deserialize`.

This release includes some utilities for converting keys to and from hex, which I have been making use of in work related to owned DBCs.