### PR TITLE
chore: upgrade blsttc to 7.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ mock = [ ]
 
 [dependencies]
 bincode = "1.3.3"
-blsttc = "6.0.0"
+blsttc = "7.0.0"
 bls_ringct = "0.2.1"
 hex = "0.4.3"
 thiserror = "1.0.24"


### PR DESCRIPTION
Crates in the `safe_network` workspace will be getting upgraded to use this new version of blsttc, so this dependent crate also needs to be upgraded.