### PR TITLE
refactor!: reducing spent proof verification public API scope to only check it is known key

### DIFF
--- a/src/dbc.rs
+++ b/src/dbc.rs
@@ -638,15 +638,15 @@ pub(crate) mod tests {
             if let Some(spent_proof) = repeating_inputs.next() {
                 let id = crate::bls_dkg_id(&mut rng);
                 let key_manager = mock::KeyManager::from(mock::Signer::from(id));
-                let sig_share = key_manager.sign(&spent_proof.content.hash()).unwrap();
+                let sig_share = key_manager.sign(&spent_proof.content.hash());
                 let sig = key_manager
-                    .public_key_set()?
+                    .public_key_set()
                     .combine_signatures(vec![sig_share.threshold_crypto()])
                     .unwrap();
 
                 let fuzzed_sp = SpentProof {
                     content: spent_proof.content.clone(),
-                    spentbook_pub_key: key_manager.public_key_set()?.public_key(),
+                    spentbook_pub_key: key_manager.public_key_set().public_key(),
                     spentbook_sig: sig,
                 };
                 // note: existing items may be replaced.
@@ -658,11 +658,10 @@ pub(crate) mod tests {
         // Valid spentbook signatures BUT signing wrong message
         for _ in 0..n_wrong_msg_sigs.coerce() {
             if let Some(spent_proof) = repeating_inputs.next() {
-                let wrong_msg_sig_share =
-                    spentbook_node.key_manager.sign(&Hash([0u8; 32])).unwrap();
+                let wrong_msg_sig_share = spentbook_node.key_manager.sign(&Hash([0u8; 32]));
                 let wrong_msg_sig = spentbook_node
                     .key_manager
-                    .public_key_set()?
+                    .public_key_set()
                     .combine_signatures(vec![wrong_msg_sig_share.threshold_crypto()])
                     .unwrap();
 
@@ -689,10 +688,10 @@ pub(crate) mod tests {
                     public_commitments: spent_proof.public_commitments().clone(),
                 };
 
-                let sig_share = spentbook_node.key_manager.sign(&content.hash()).unwrap();
+                let sig_share = spentbook_node.key_manager.sign(&content.hash());
                 let sig = spentbook_node
                     .key_manager
-                    .public_key_set()?
+                    .public_key_set()
                     .combine_signatures(vec![sig_share.threshold_crypto()])
                     .unwrap();
 

--- a/src/mock/error.rs
+++ b/src/mock/error.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 use serde::{Deserialize, Serialize};
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Error, Debug, Clone, PartialEq)]
+#[derive(Error, Debug, Clone, PartialEq, Eq)]
 /// Mock error variants.
 pub enum Error {
     #[error("Key image has already been spent")]

--- a/src/mock/genesis_builder.rs
+++ b/src/mock/genesis_builder.rs
@@ -56,15 +56,10 @@ impl GenesisBuilder {
         if !self.spentbook_nodes.is_empty() {
             // we only support a single mock spentbook section.  pubkeys must match.
             assert_eq!(
-                spentbook_node
-                    .key_manager
-                    .public_key_set()
-                    .unwrap()
-                    .public_key(),
+                spentbook_node.key_manager.public_key_set().public_key(),
                 self.spentbook_nodes[0]
                     .key_manager
                     .public_key_set()
-                    .unwrap()
                     .public_key()
             );
         }

--- a/src/mock/spentbook.rs
+++ b/src/mock/spentbook.rs
@@ -199,8 +199,8 @@ impl SpentBookNode {
                 public_commitments,
             };
 
-            let spentbook_pks = self.key_manager.public_key_set()?;
-            let spentbook_sig_share = self.key_manager.sign(&sp_content.hash())?;
+            let spentbook_pks = self.key_manager.public_key_set();
+            let spentbook_sig_share = self.key_manager.sign(&sp_content.hash());
 
             Ok(SpentProofShare {
                 content: sp_content,

--- a/src/owner.rs
+++ b/src/owner.rs
@@ -139,7 +139,7 @@ impl From<OwnerOnce> for Owner {
 /// The one-time-use Owner key(pair) is derived from a reusable
 /// base Owner key(pair) using the DerivationIndex.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct OwnerOnce {
     pub owner_base: Owner,
     pub derivation_index: DerivationIndex,


### PR DESCRIPTION
- Small refactor to `SpentProof` verifier public `Trait` API, reducing its scope to be a verifier of just known pub keys performing signature verification in the `SpentProof` itself before calling the `Trait`'s function.
- Minor simplification to mock key-manager and removing some unwraps from tests.