### PR TITLE
feat: function to get commitments from transaction

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -56,6 +56,11 @@ pub enum Error {
     )]
     SpentProofInputLenMismatch { current: usize, expected: usize },
 
+    #[error(
+        "The number of commitments ({current}) does not match the number of input MlsagSignature ({expected})"
+    )]
+    CommitmentsInputLenMismatch { current: usize, expected: usize },
+
     #[error("A SpentProof KeyImage does not match an MlsagSignature KeyImage")]
     SpentProofInputKeyImageMismatch,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ pub use crate::{
         SpentProofShare,
     },
     token::Token,
-    verification::TransactionVerifier,
+    verification::{get_public_commitments_from_transaction, TransactionVerifier},
 };
 
 #[cfg(feature = "serde")]


### PR DESCRIPTION
This is some code that currently exists in the node implementation when we are processing a spend request. It needs to be shared between a couple of crates in the `safe_network` workspace, so I'm opting to move it into this crate, which makes more sense than putting it in `sn_interface`, since it's very specific to DBCs.

No test coverage has been added because it's difficult to setup the conditions for testing the function. This could be done at a later point.

It could have potentially went into the transaction verifier, but I'm reluctant to change the behaviour of that without having any tests. At the moment it would cost me too much time to work out all the conditions necessary for covering the code in `TransactionVerifier`.