### PR TITLE
chore: upgrade blsttc and bls_ringct

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ mock = [ ]
 
 [dependencies]
 bincode = "1.3.3"
-blsttc = "8.0.0"
-bls_ringct = "1.1.1"
+blsttc = "8.0.1"
+bls_ringct = "1.1.2"
 hex = "0.4.3"
 thiserror = "1.0.24"
 


### PR DESCRIPTION
This facilitates having one version of `blstrs` in the dependency graph and hence removing a dependency on a crate that has been yanked.