### PR TITLE
Remove input's associated spent tx from the DBC struct

### DIFF
--- a/benches/reissue.rs
+++ b/benches/reissue.rs
@@ -41,8 +41,8 @@ fn bench_reissue_1_to_100(c: &mut Criterion) {
         .build(&mut rng)
         .unwrap();
 
-    for (key_image, tx) in dbc_builder.inputs() {
-        let spent_proof_share = spentbook.log_spent(key_image, tx).unwrap();
+    for (spent_key, tx) in dbc_builder.inputs() {
+        let spent_proof_share = spentbook.log_spent(spent_key, tx).unwrap();
         dbc_builder = dbc_builder.add_spent_proof_share(spent_proof_share);
     }
 
@@ -88,8 +88,8 @@ fn bench_reissue_100_to_1(c: &mut Criterion) {
         .build(&mut rng)
         .unwrap();
 
-    for (key_image, tx) in dbc_builder.inputs() {
-        let spent_proof_share = spentbook_node.log_spent(key_image, tx).unwrap();
+    for (spent_key, tx) in dbc_builder.inputs() {
+        let spent_proof_share = spentbook_node.log_spent(spent_key, tx).unwrap();
         dbc_builder = dbc_builder.add_spent_proof_share(spent_proof_share);
     }
     let dbcs = dbc_builder.build(&spentbook_node.key_manager).unwrap();
@@ -109,8 +109,8 @@ fn bench_reissue_100_to_1(c: &mut Criterion) {
         .build(&mut rng)
         .unwrap();
 
-    for (key_image, tx) in merge_dbc_builder.inputs() {
-        let spent_proof_share = spentbook_node.log_spent(key_image, tx).unwrap();
+    for (spent_key, tx) in merge_dbc_builder.inputs() {
+        let spent_proof_share = spentbook_node.log_spent(spent_key, tx).unwrap();
         merge_dbc_builder = merge_dbc_builder.add_spent_proof_share(spent_proof_share);
     }
 
@@ -156,8 +156,8 @@ fn generate_dbc_of_value(
         }))
         .build(rng)?;
 
-    for (key_image, tx) in dbc_builder.inputs() {
-        let spent_proof_share = spentbook_node.log_spent(key_image, tx)?;
+    for (spent_key, tx) in dbc_builder.inputs() {
+        let spent_proof_share = spentbook_node.log_spent(spent_key, tx)?;
         dbc_builder = dbc_builder.add_spent_proof_share(spent_proof_share);
     }
 

--- a/examples/mint-repl/mint-repl.rs
+++ b/examples/mint-repl/mint-repl.rs
@@ -761,7 +761,9 @@ fn reissue_auto_cli(mintinfo: &mut MintInfo) -> Result<()> {
             }
         }
         let outputs = match &input_dbcs[..] {
-            [dbc] if dbc == &mintinfo.genesis => dbc_builder.build_without_verifying()?,
+            [dbc] if dbc == &mintinfo.genesis => {
+                dbc_builder.build(&mintinfo.spentbook()?.key_manager)?
+            }
             _ => dbc_builder.build(&mintinfo.spentbook()?.key_manager)?,
         };
         let output_dbcs: Vec<Dbc> = outputs.into_iter().map(|(dbc, ..)| dbc).collect();

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -272,14 +272,6 @@ impl DbcBuilder {
         // note that we do this just once for entire Tx, not once per output Dbc.
         TransactionVerifier::verify(verifier, &self.transaction, &spent_proofs)?;
 
-        // verify there is a matching spent transaction for each spent_proof
-        if !spent_proofs.iter().all(|proof| {
-            self.spent_transactions
-                .contains_key(&proof.transaction_hash())
-        }) {
-            return Err(Error::MissingSpentTransaction);
-        }
-
         // build output DBCs
         self.build_output_dbcs(spent_proofs)
     }
@@ -335,7 +327,6 @@ impl DbcBuilder {
                     )),
                     transaction: self.transaction.clone(),
                     spent_proofs: spent_proofs.clone(),
-                    spent_transactions: self.spent_transactions.values().cloned().collect(),
                 };
                 (dbc, owner_once.clone(), amount_secrets_list[0].clone())
             })

--- a/src/dbc.rs
+++ b/src/dbc.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::transaction::{DbcTransaction, OutputProof, RevealedCommitment, RevealedInput};
 use crate::{
-    AmountSecrets, DbcContent, DerivationIndex, Error, Hash, Owner, Result, SpentProof,
+    AmountSecrets, DbcContent, DerivationIndex, Error, Owner, Result, SpentProof,
     SpentProofKeyVerifier, TransactionVerifier,
 };
 
@@ -141,7 +141,7 @@ impl Dbc {
     /// returns PublicKey for the owner's derived public key
     /// This is useful for checking if a Dbc has been spent.
     /// will return an error if the SecretKey is not available.  (not bearer)
-    pub fn key_image_bearer(&self) -> Result<PublicKey> {
+    pub fn public_key_bearer(&self) -> Result<PublicKey> {
         self.public_key(&self.owner_base().secret_key()?)
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -46,9 +46,6 @@ pub enum Error {
     #[error("OutputProof not found in transaction outputs")]
     OutputProofNotFound,
 
-    #[error("Missing spent transaction for at least one of the spent proofs")]
-    MissingSpentTransaction,
-
     #[error("public key is not unique across all transaction outputs")]
     PublicKeyNotUniqueAcrossOutputs,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub mod mock;
 pub use blsttc;
 pub use blsttc::rand;
 pub use blsttc::{PublicKey, PublicKeySet, Signature, SignatureShare};
+pub use bulletproofs::PedersenGens;
 
 pub use crate::{
     amount_secrets::AmountSecrets,

--- a/src/mock/genesis_builder.rs
+++ b/src/mock/genesis_builder.rs
@@ -87,10 +87,10 @@ impl GenesisBuilder {
             )
             .build(rng)?;
 
-        for (key_image, tx) in dbc_builder.inputs() {
+        for (public_key, tx) in dbc_builder.inputs() {
             for spentbook_node in self.spentbook_nodes.iter_mut() {
                 dbc_builder = dbc_builder
-                    .add_spent_proof_share(spentbook_node.log_spent(key_image, tx.clone())?);
+                    .add_spent_proof_share(spentbook_node.log_spent(public_key, tx.clone())?);
             }
             dbc_builder = dbc_builder.add_spent_transaction(tx);
         }


### PR DESCRIPTION
Remove input's associated spent transactions from the DBC struct:
- they where unused by `sn_dbc`
- they forced DBCs to include all input's Tx which doesn't apply to Genesis DBC
- broke `mint-repl` and benches as a result, thus breaking all `sn_dbc` operating examples
- removes extra verifications that don't prove anything apart from the fact that those spent transactions are indeed included in the DBC, the input's `SpentProof` is the one we want to check and do check.

Keeping them would involve a rather inelegant solution IMO:
- creating a fake Tx for genesis to tolerate this case
- creating a special case in the code just for the Genesis everywhere DBC checks are involved
- or maybe I didn't see something else?