### PR TITLE
fix: cargo keywords

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,7 @@ keywords = [
   "Safe",
   "Network",
   "SafeNetwork",
-  "DBC",
-  "DigitalBearerCertificates"
+  "DBC"
 ]
 authors = [ "MaidSafe Developers <dev@maidsafe.net>" ]
 edition = "2018"


### PR DESCRIPTION
`invalid length 25, expected a keyword with less than 20 characters at line 1 column 5198`