### PR TITLE
chore: skip SpentProofContent::Commitment from Debug output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ mock = [ ]
 bincode = "1.3.3"
 blsttc = "8.0.1"
 bulletproofs = "4.0.0"
+custom_debug = "~0.5.0"
 hex = "0.4.3"
 merlin = "3.0.0"
 thiserror = "1.0.24"

--- a/src/spent_proof.rs
+++ b/src/spent_proof.rs
@@ -10,6 +10,8 @@ use crate::{Commitment, Error, Hash, PublicKey, PublicKeySet, Result, Signature,
 
 use std::cmp::Ordering;
 
+use custom_debug::Debug;
+
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -23,6 +25,7 @@ pub struct SpentProofContent {
     /// Hash of transaction that input Dbc is being spent in.
     pub transaction_hash: Hash,
 
+    #[debug(skip)]
     /// public commitment for the transaction
     pub public_commitment: Commitment,
 }


### PR DESCRIPTION
Example of what's to be removed from `Debug` output:
```
EdwardsPoint{
	X: FieldElement51([1043238431477456, 1419548070203189, 1665403042619870, 1386198998947853, 515752123883868]),
	Y: FieldElement51([1929334465132752, 538744156346088, 2185247123532768, 1716762503190716, 1661212489023079]),
	Z: FieldElement51([1, 0, 0, 0, 0]),
	T: FieldElement51([304717595454192, 97546745304059, 2115877759720500, 1172656241084752, 207339791232573])
}
EdwardsPoint{
	X: FieldElement51([1399723944465364, 1920466957480183, 1153056081148392, 1624516982794237, 1503656482862715]),
	Y: FieldElement51([2230247505271161, 1301785824785078, 485010775944390, 1196054786803259, 903682422504527]),
	Z: FieldElement51([2251799813685233, 2251799813685247, 2251799813685247, 2251799813685247, 2251799813685247]),
	T: FieldElement51([1032929431868461, 1861612832469011, 543688215858991, 2064774476716732, 1422440648754953])
}
EdwardsPoint{
	X: FieldElement51([330645901460653, 1077207160242986, 93787270576261, 1210603445264329, 188791318149773]),
	Y: FieldElement51([1289861394209927, 96823188300892, 266210760609919, 2140149241978124, 110549484963424]),
	Z: FieldElement51([2251799813685233, 2251799813685247, 2251799813685247, 2251799813685247, 2251799813685247]),
	T: FieldElement51([1218870381816768, 390186981216236, 1708111597826256, 187025336968515, 829359164930294])
}
EdwardsPoint{
	X: FieldElement51([852075869219865, 331332856205064, 1098743732536855, 627282830891010, 748143330822532]),
	Y: FieldElement51([21552308414068, 950013988900169, 1766789037740857, 1055745026881988, 1348117391180720]),
	Z: FieldElement51([2251799813685233, 2251799813685247, 2251799813685247, 2251799813685247, 2251799813685247]),
	T: FieldElement51([1032929431868461, 1861612832469011, 543688215858991, 2064774476716732, 1422440648754953])
```
