### PR TITLE
refactor!: include spend src tx hash and simplify builder api

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -55,7 +55,15 @@ impl TransactionBuilder {
     }
 
     /// Add an input given a list of Dbcs and associated MainKeys.
-    pub fn add_inputs_dbc(
+    pub fn add_input_dbcs(mut self, main_key: &MainKey, dbcs: &[Dbc]) -> Result<Self> {
+        for dbc in dbcs.iter() {
+            self = self.add_input_dbc(dbc, main_key)?;
+        }
+        Ok(self)
+    }
+
+    /// Add an input given a list of Dbcs and associated MainKeys.
+    pub fn add_input_dbcs_with_keys(
         mut self,
         dbcs: impl IntoIterator<Item = (Dbc, MainKey)>,
     ) -> Result<Self> {

--- a/src/dbc_ciphers.rs
+++ b/src/dbc_ciphers.rs
@@ -71,7 +71,7 @@ impl From<(&PublicAddress, &DerivationIndex, RevealedAmount)> for DbcCiphers {
         let derivation_index_cipher = public_address.encrypt(derivation_index);
         let revealed_amount_cipher = public_address
             .new_dbc_id(derivation_index)
-            .encrypt(revealed_amount);
+            .encrypt(&revealed_amount);
 
         Self {
             public_address: *public_address,

--- a/src/dbc_id.rs
+++ b/src/dbc_id.rs
@@ -37,7 +37,7 @@ impl DbcId {
         self.0.verify(sig, msg)
     }
 
-    pub fn encrypt(&self, revealed_amount: RevealedAmount) -> Ciphertext {
+    pub fn encrypt(&self, revealed_amount: &RevealedAmount) -> Ciphertext {
         self.0.encrypt(revealed_amount.to_bytes())
     }
 }

--- a/src/dbc_id.rs
+++ b/src/dbc_id.rs
@@ -118,6 +118,11 @@ impl PublicAddress {
         Self(public_key)
     }
 
+    /// Verify that the signature is valid for the message.
+    pub fn verify(&self, sig: &blsttc::Signature, msg: &[u8]) -> bool {
+        self.0.verify(sig, msg)
+    }
+
     /// A random derivation index and the public address.
     /// The random index will be used to derive a DbcId out of the public address.
     pub fn random_dbc_id_src(&self, rng: &mut impl RngCore) -> DbcIdSource {

--- a/src/dbc_id.rs
+++ b/src/dbc_id.rs
@@ -175,6 +175,11 @@ impl MainKey {
         }
     }
 
+    /// Sign a message with the main key.
+    pub fn sign(&self, msg: &[u8]) -> blsttc::Signature {
+        self.0.sign(msg)
+    }
+
     /// When someone wants to send tokens to the PublicAddress of this MainKey,
     /// they generate the id of the Dbc - the DbcId - that shall hold the tokens.
     /// The created Dbc contains the encrypted derivation index, that is decrypted using

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,6 +38,12 @@ pub enum Error {
     #[error("Transaction hash does not match the transaction signed by spentbook.")]
     InvalidTransactionHash,
 
+    #[error("Missing a src transaction {src_tx_hash:?} of a signed spend {dbc_id:?}.")]
+    MissingSpentSrcTransaction {
+        dbc_id: DbcId,
+        src_tx_hash: crate::Hash,
+    },
+
     #[error("Dbc ciphers are not present in transaction outputs.")]
     DbcCiphersNotPresentInTransactionOutput,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,10 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use std::fmt;
-
-#[cfg(feature = "serde")]
-use std::str::FromStr;
+#![allow(clippy::result_large_err)]
 
 mod blst;
 mod builder;
@@ -51,6 +48,9 @@ pub use crate::{
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+use std::fmt;
+#[cfg(feature = "serde")]
+use std::str::FromStr;
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Default)]

--- a/src/mock/genesis_builder.rs
+++ b/src/mock/genesis_builder.rs
@@ -58,7 +58,8 @@ impl GenesisBuilder {
             )
             .build(Hash::default(), rng)?;
 
-        for (tx, signed_spend) in dbc_builder.signed_spends() {
+        let tx = &dbc_builder.dst_tx;
+        for signed_spend in dbc_builder.signed_spends() {
             for spentbook_node in self.spentbook_nodes.iter_mut() {
                 spentbook_node.log_spent(tx, signed_spend)?;
             }

--- a/src/mock/genesis_material.rs
+++ b/src/mock/genesis_material.rs
@@ -8,8 +8,8 @@
 
 use crate::{
     dbc_id::DbcIdSource,
-    transaction::{Amount, Output, RevealedAmount, RevealedInput, RevealedTx},
-    DbcId, DerivedKey, MainKey,
+    transaction::{Amount, InputHistory, Output, RevealedAmount, RevealedInput, RevealedTx},
+    DbcId, DbcTransaction, DerivedKey, MainKey,
 };
 use blsttc::IntoFr;
 
@@ -57,9 +57,19 @@ impl Default for GenesisMaterial {
         );
         let input_dbc_id = revealed_input.dbc_id();
 
-        // build the pre-genesis Transaction
+        let input_history = InputHistory {
+            input: revealed_input,
+            // There is nothing in this transaction
+            // since there was no tx before genesis.
+            input_src_tx: DbcTransaction {
+                inputs: vec![],
+                outputs: vec![],
+            },
+        };
+
+        // Build the transaction where genesis was created.
         let genesis_tx = RevealedTx {
-            inputs: vec![revealed_input],
+            inputs: vec![input_history],
             outputs: vec![Output::new(
                 output_derived_key.dbc_id(),
                 Self::GENESIS_AMOUNT,

--- a/src/spentbook.rs
+++ b/src/spentbook.rs
@@ -210,7 +210,7 @@ mod tests {
             .collect();
 
         let dbc_builder = TransactionBuilder::default()
-            .add_inputs_dbc(second_inputs_dbcs)?
+            .add_input_dbcs_with_keys(second_inputs_dbcs)?
             .add_outputs(
                 second_output_key_map
                     .values()

--- a/src/transaction/amount.rs
+++ b/src/transaction/amount.rs
@@ -4,9 +4,9 @@
 // This SAFE Network Software is licensed under the BSD-3-Clause license.
 // Please see the LICENSE file for more details.
 
-use crate::{rand::RngCore, BlindedAmount, BlindingFactor, DerivedKey, Error, Result};
+use crate::{rand::RngCore, BlindedAmount, BlindingFactor, DbcId, DerivedKey, Error, Result};
 
-use blsttc::{rand::CryptoRng, Ciphertext, PublicKey};
+use blsttc::{rand::CryptoRng, Ciphertext};
 use bulletproofs::PedersenGens;
 use std::convert::TryFrom;
 
@@ -56,9 +56,9 @@ impl RevealedAmount {
         self.blinding_factor
     }
 
-    /// Encrypt this instance to given public key, producing `Ciphertext`.
-    pub fn encrypt(&self, public_key: &PublicKey) -> Ciphertext {
-        public_key.encrypt(self.to_bytes())
+    /// Encrypt this instance to given `DbcId`, producing `Ciphertext`.
+    pub fn encrypt(&self, dbc_id: &DbcId) -> Ciphertext {
+        dbc_id.encrypt(self)
     }
 
     /// Build RevealedAmount from fixed size byte array.


### PR DESCRIPTION
The `spend src tx hash` is the hash of the tx where the dbc to be spent, was created. In other words: that src tx shall contain this spend as an output.

Also extends misc apis.