### PR TITLE
refactor!: have dbcs take derived key

### DIFF
--- a/benches/reissue.rs
+++ b/benches/reissue.rs
@@ -26,8 +26,9 @@ fn bench_reissue_1_to_100(c: &mut Criterion) {
     let (mut spentbook_node, (starting_dbc, starting_main_key)) =
         generate_dbc_of_value(Token::from_nano(N_OUTPUTS), &mut rng).unwrap();
 
+    let derived_key = starting_dbc.derived_key(&starting_main_key).unwrap();
     let dbc_builder = sn_dbc::TransactionBuilder::default()
-        .add_input_dbc(&starting_dbc, &starting_main_key)
+        .add_input_dbc(&starting_dbc, &derived_key)
         .unwrap()
         .add_outputs((0..N_OUTPUTS).map(|_| {
             (
@@ -77,8 +78,9 @@ fn bench_reissue_100_to_1(c: &mut Criterion) {
         })
         .collect();
 
+    let derived_key = starting_dbc.derived_key(&starting_main_key).unwrap();
     let dbc_builder = sn_dbc::TransactionBuilder::default()
-        .add_input_dbc(&starting_dbc, &starting_main_key)
+        .add_input_dbc(&starting_dbc, &derived_key)
         .unwrap()
         .add_outputs(
             outputs
@@ -109,7 +111,8 @@ fn bench_reissue_100_to_1(c: &mut Criterion) {
 
     for (dbc, _) in dbcs.into_iter() {
         let (main_key, _, _) = outputs.get(&dbc.id()).unwrap();
-        tx_builder = tx_builder.add_input_dbc(&dbc, main_key).unwrap();
+        let derived_key = dbc.derived_key(main_key).unwrap();
+        tx_builder = tx_builder.add_input_dbc(&dbc, &derived_key).unwrap();
     }
 
     let merge_dbc_builder = tx_builder
@@ -168,8 +171,9 @@ fn generate_dbc_of_value(
 
     let main_key = MainKey::random_from_rng(rng);
 
+    let derived_key = genesis_dbc.derived_key(&genesis_material.main_key).unwrap();
     let dbc_builder = sn_dbc::TransactionBuilder::default()
-        .add_input_dbc(&genesis_dbc, &genesis_material.main_key)
+        .add_input_dbc(&genesis_dbc, &derived_key)
         .unwrap()
         .add_outputs(output_amounts.into_iter().map(|amount| {
             (

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -78,25 +78,6 @@ impl TransactionBuilder {
         Ok(self)
     }
 
-    // /// Add an input given a DerivedKey and a RevealedAmount.
-    // pub fn add_input_by_secrets(
-    //     mut self,
-    //     derived_key: DerivedKey,
-    //     revealed_amount: RevealedAmount,
-    // ) -> Self {
-    //     let revealed_input = RevealedInput::new(derived_key, revealed_amount);
-    //     self = self.add_input(revealed_input);
-    //     self
-    // }
-
-    // /// Add an input given a list of (DerivedKey, RevealedAmount).
-    // pub fn add_inputs_by_secrets(mut self, secrets: Vec<(DerivedKey, RevealedAmount)>) -> Self {
-    //     for (derived_key, revealed_amount) in secrets.into_iter() {
-    //         self = self.add_input_by_secrets(derived_key, revealed_amount);
-    //     }
-    //     self
-    // }
-
     /// Add an output given amount and the source of the DbcId for the new Dbc.
     pub fn add_output(mut self, amount: Token, dbc_id_src: DbcIdSource) -> Self {
         let output = Output::new(dbc_id_src.dbc_id(), amount.as_nano());

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -14,7 +14,7 @@ use crate::{
     transaction::{
         DbcTransaction, InputHistory, Output, RevealedAmount, RevealedOutput, RevealedTx,
     },
-    DbcId, MainKey,
+    DbcId, DerivedKey,
 };
 use crate::{
     rand::{CryptoRng, RngCore},
@@ -48,9 +48,9 @@ impl TransactionBuilder {
         self
     }
 
-    /// Add an input given a Dbc and associated MainKey.
-    pub fn add_input_dbc(mut self, dbc: &Dbc, main_key: &MainKey) -> Result<Self> {
-        let input = dbc.revealed_input(main_key)?;
+    /// Add an input given a Dbc and its DerivedKey.
+    pub fn add_input_dbc(mut self, dbc: &Dbc, derived_key: &DerivedKey) -> Result<Self> {
+        let input = dbc.revealed_input(derived_key)?;
         let input_src_tx = dbc.src_tx.clone();
         self = self.add_input(InputHistory {
             input,
@@ -59,21 +59,10 @@ impl TransactionBuilder {
         Ok(self)
     }
 
-    /// Add an input given a list of Dbcs and associated MainKeys.
-    pub fn add_input_dbcs(mut self, main_key: &MainKey, dbcs: &[Dbc]) -> Result<Self> {
-        for dbc in dbcs.iter() {
-            self = self.add_input_dbc(dbc, main_key)?;
-        }
-        Ok(self)
-    }
-
-    /// Add an input given a list of Dbcs and associated MainKeys.
-    pub fn add_input_dbcs_with_keys(
-        mut self,
-        dbcs: impl IntoIterator<Item = (Dbc, MainKey)>,
-    ) -> Result<Self> {
-        for (dbc, main_key) in dbcs.into_iter() {
-            self = self.add_input_dbc(&dbc, &main_key)?;
+    /// Add an input given a list of Dbcs and associated DerivedKeys.
+    pub fn add_input_dbcs(mut self, dbcs: &[(Dbc, DerivedKey)]) -> Result<Self> {
+        for (dbc, derived_key) in dbcs.iter() {
+            self = self.add_input_dbc(dbc, derived_key)?;
         }
         Ok(self)
     }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -50,7 +50,7 @@ impl TransactionBuilder {
 
     /// Add an input given a Dbc and associated MainKey.
     pub fn add_input_dbc(mut self, dbc: &Dbc, main_key: &MainKey) -> Result<Self> {
-        let input = dbc.as_revealed_input(main_key)?;
+        let input = dbc.revealed_input(main_key)?;
         let input_src_tx = dbc.src_tx.clone();
         self = self.add_input(InputHistory {
             input,

--- a/src/dbc.rs
+++ b/src/dbc.rs
@@ -127,7 +127,7 @@ impl Dbc {
 
     /// Return the input that represents this Dbc for use as
     /// a transaction input.
-    pub fn as_revealed_input(&self, main_key: &MainKey) -> Result<RevealedInput> {
+    pub fn revealed_input(&self, main_key: &MainKey) -> Result<RevealedInput> {
         Ok(RevealedInput::new(
             self.derived_key(main_key)?,
             self.revealed_amount(main_key)?,
@@ -329,8 +329,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn as_revealed_input_should_error_if_dbc_id_is_not_derived_from_main_key() -> Result<(), Error>
-    {
+    fn revealed_input_should_error_if_dbc_id_is_not_derived_from_main_key() -> Result<(), Error> {
         let mut rng = crate::rng::from_seed([0u8; 32]);
         let (_, _, (dbc, _)) = generate_dbc_of_value_from_pk_hex(
             100,
@@ -342,7 +341,7 @@ pub(crate) mod tests {
             "d823b03be25ad306ce2c2ef8f67d8a49322ed2a8636de5dbf01f6cc3467dc91e",
         )?;
         let main_key = MainKey::new(sk);
-        let result = dbc.as_revealed_input(&main_key);
+        let result = dbc.revealed_input(&main_key);
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err().to_string(),


### PR DESCRIPTION
Have dbcs take derived key. This makes more sense in upper layer (bearer scenario for testing)

Correct fn name, prefixing with `as` is usually done consuming self, which we don't do.

Remove commented out.