### PR TITLE
Obsoleting the sending of DBCs

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -5,17 +5,19 @@ A user has a main key - `MainKey` - which is a `bls::SecretKey`.
 It is in essense a key _pair_, as the corresponding `bls::PublicKey` can be gotten from that secret key.
 The `bls::PublicKey`of that key pair, is the `PublicAddress` to which anyone can send tokens.
 
-- A `Dbc` is a vehicle for transfering tokens.
+- A `Dbc` is a container that holds value (counted in tokens).
 
 - A `Dbc` has a unique identifier, `DbcId`, which is a `bls::PublicKey`.
 The corresponding `bls::SecretKey` called `DerivedKey`, unlocks the value.
 
 - A `Dbc` can only be fully spent. So you unlock it and take out all the tokens, and the `Dbc` is spent.
 
+- A `Dbc` cannot be made public as it contains secrets, what the Network only ever sees is `SignedSpend`, which tells us which `Dbc` was spent
+
 ### Sending tokens:
-When you send tokens to someone, you create a new `Dbc`, with a `DbcId` (a `bls::PublicKey`) by deriving it from the `PublicAddress` (a `bls::PublicKey`) of someone. You derive it using a random `DerivationIndex`, which you include (encrypted to the `PublicAddress`, which means only the corresponding `MainKey` can decrypt it) in the newly created `Dbc`.
+When you send tokens to someone, you create a new `Dbc`, with a `DbcId` (a `bls::PublicKey`) by deriving it from the `PublicAddress` (a `bls::PublicKey`) of someone. You derive it using a random `DerivationIndex`, which you include in the newly created `Dbc`.
 Also included in this new `Dbc` are the signatures of network nodes verifying that the input `Dbc(s)` that you emptied to create this new `Dbc`, are actually spent and was included in the transaction where this new `Dbc` was created. (The signatures part will change with the new network design.)
+Since `Dbc`s contain secrets, they should be encrypted before being sent. 
 
 ### Unknown connection between Dbcs and PublicAddresses:
 Since the `DbcId` is derived from the `PublicAddress`, using a secret `DerivationIndex`, no one except sender and receiver knows that this new `Dbc` was sent to the `PublicAddress` of the receiver.
-The recipient decrypts the `DerivationIndex` cipher, using their `MainKey` (remember, it's the corresponding `bls::SecretKey` of the `bls::PublicKey` in the `PublicAddress`).

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -10,7 +10,7 @@ use crate::{
     transaction::{DbcTransaction, Output},
     DbcId, DerivationIndex, DerivedKey, FeeOutput, Input, PublicAddress, Spend,
 };
-use crate::{Dbc, DbcCiphers, Error, Hash, Result, SignedSpend, Token};
+use crate::{Dbc, DbcSecrets, Error, Hash, Result, SignedSpend, Token};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
@@ -237,7 +237,7 @@ impl DbcBuilder {
                     Dbc {
                         id: public_address.new_dbc_id(derivation_index),
                         src_tx: self.spent_tx.clone(),
-                        ciphers: DbcCiphers::from((public_address, derivation_index)),
+                        secrets: DbcSecrets::from((public_address, derivation_index)),
                         signed_spends: self.signed_spends.clone(),
                     },
                     output.token,

--- a/src/dbc.rs
+++ b/src/dbc.rs
@@ -216,11 +216,11 @@ pub(crate) mod tests {
             outputs: vec![Output::new(derived_key.dbc_id(), amount)],
             fee: FeeOutput::new(Hash::default(), 3_500, Hash::default()),
         };
-        let ciphers = DbcSecrets::from((&main_key.public_address(), &derivation_index));
+        let secrets = DbcSecrets::from((&main_key.public_address(), &derivation_index));
         let dbc = Dbc {
             id: derived_key.dbc_id(),
             src_tx: tx,
-            secrets: ciphers,
+            secrets,
             signed_spends: Default::default(),
         };
 
@@ -247,11 +247,11 @@ pub(crate) mod tests {
             outputs: vec![Output::new(derived_key.dbc_id(), amount)],
             fee: FeeOutput::new(Hash::default(), 2_500, Hash::default()),
         };
-        let ciphers = DbcSecrets::from((&main_key.public_address(), &derivation_index));
+        let secrets = DbcSecrets::from((&main_key.public_address(), &derivation_index));
         let dbc = Dbc {
             id: derived_key.dbc_id(),
             src_tx: tx,
-            secrets: ciphers,
+            secrets,
             signed_spends: Default::default(),
         };
 
@@ -303,11 +303,11 @@ pub(crate) mod tests {
             fee: FeeOutput::default(),
         };
 
-        let ciphers = DbcSecrets::from((&main_key.public_address(), &derivation_index));
+        let secrets = DbcSecrets::from((&main_key.public_address(), &derivation_index));
         let dbc = Dbc {
             id: derived_key.dbc_id(),
             src_tx: tx,
-            secrets: ciphers,
+            secrets,
             signed_spends: Default::default(),
         };
 

--- a/src/dbc_id.rs
+++ b/src/dbc_id.rs
@@ -77,7 +77,7 @@ impl DerivedKey {
 /// corresponding to that DbcId, and thus unlock the value of the Dbc by using that DerivedKey.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Debug, PartialEq, Eq, Ord, PartialOrd, Clone)]
-pub struct PublicAddress(PublicKey);
+pub struct PublicAddress(pub PublicKey);
 
 impl PublicAddress {
     pub fn new(public_key: PublicKey) -> Self {
@@ -115,6 +115,11 @@ impl MainKey {
     ///
     pub fn new(secret_key: SecretKey) -> Self {
         Self(SerdeSecret(secret_key))
+    }
+
+    /// Get the secret key.
+    pub fn secret_key(&self) -> &SecretKey {
+        &self.0
     }
 
     /// This is the static public address which is shared with others, and

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ pub mod mock;
 pub use crate::{
     builder::{DbcBuilder, TransactionBuilder},
     dbc::Dbc,
-    dbc_ciphers::DbcCiphers,
+    dbc_ciphers::DbcSecrets,
     dbc_id::{random_derivation_index, DbcId, DerivationIndex, DerivedKey, MainKey, PublicAddress},
     error::{Error, Result},
     fee_output::FeeOutput,


### PR DESCRIPTION
This PR renders the sending of DBCs obsolete as their secrets are not encrypted anymore. 
DBCs become nothing more than the way local wallets keep track of their money. 
This is a first step towards the dusking of DBCs altogether. 