### PR TITLE
fixed forum link because of domain name change

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Multi-sig is a concern of the user of this library.
 
 Some writeups about the technology can be found at:
 
-https://safenetforum.org/t/safenetwork-dbc-technical-series
+https://forum.autonomi.community/t/safenetwork-dbc-technical-series
 
 
 # Building


### PR DESCRIPTION
just a fix for the DBC "writeups about the technology" that have been linked but the domain name of the forum changed by now